### PR TITLE
added val_speed and adv_speed config with test cases

### DIFF
--- a/network/interface.py
+++ b/network/interface.py
@@ -88,6 +88,15 @@ def device_interfaces_list(request):
                             else None
                         )
                     ),
+                    link_training=(
+                        True
+                        if str(req_data.get("link_training")).lower() == "on"
+                        else (
+                            False
+                            if str(req_data.get("link_training")).lower() == "off"
+                            else None
+                        )
+                    ),
                     adv_speeds=req_data.get("adv_speeds"),
                 )
                 add_msg_to_list(result, get_success_msg(request))

--- a/network/test/test_interface.py
+++ b/network/test/test_interface.py
@@ -232,10 +232,6 @@ class TestInterface(TestORCA):
 
         # storing the auto-negotiate and advertised-speed
         pre_autoneg = response_1.json()["autoneg"]
-        adv_speeds = response_1.json()["valid_speeds"]
-        speed = response_1.json()["speed"]
-        fec = response_1.json()["fec"]
-
 
         # setting the auto-negotiate to on or off with respective to previous auto-negotiate value
         # and creating request body
@@ -245,9 +241,6 @@ class TestInterface(TestORCA):
                 "mgt_ip": device_ip,
                 "name": ether_name,
                 "autoneg": set_autoneg,
-                "adv_speeds": adv_speeds,
-                "speed": speed,
-                "fec": fec
             },
         )
 
@@ -271,9 +264,6 @@ class TestInterface(TestORCA):
                 "mgt_ip": device_ip,
                 "name": ether_name,
                 "autoneg": pre_autoneg,
-                "adv_speeds": adv_speeds,
-                "speed": speed,
-                "fec": fec
             },
         )
         response = self.put_req("device_interface_list", request_body)
@@ -300,9 +290,7 @@ class TestInterface(TestORCA):
 
         # storing the lvariables and creating request body
         pre_link_training = response_1.json()["link_training"]
-        adv_speeds = response_1.json()["valid_speeds"]
-        speed = response_1.json()["speed"]
-        fec = response_1.json()["fec"]
+   
 
         set_link_training = "on" if pre_link_training == "off" else "off"
         request_body = (
@@ -310,9 +298,6 @@ class TestInterface(TestORCA):
                 "mgt_ip": device_ip,
                 "name": ether_name,
                 "link_training": set_link_training,
-                "adv_speeds": adv_speeds,
-                "speed": speed,
-                "fec": fec,
             },
         )
 
@@ -336,9 +321,6 @@ class TestInterface(TestORCA):
                 "mgt_ip": device_ip,
                 "name": ether_name,
                 "link_training": pre_link_training,
-                "adv_speeds": adv_speeds,
-                "speed": speed,
-                "fec": fec,
             },
         )
 
@@ -366,11 +348,9 @@ class TestInterface(TestORCA):
         )
 
         # crating variables to set the values
-        link_training = response_1.json()["link_training"]
         adv_speeds = response_1.json()["adv_speeds"]
         valid_speeds = response_1.json()["valid_speeds"]
-        speed = response_1.json()["speed"]
-        fec = response_1.json()["fec"]
+
         
         if adv_speeds == 'all': 
             set_adv_speed = valid_speeds
@@ -381,10 +361,7 @@ class TestInterface(TestORCA):
             {
                 "mgt_ip": device_ip,
                 "name": ether_name,
-                "link_training": link_training,
                 "adv_speeds": set_adv_speed,
-                "speed": speed,
-                "fec": fec,
             },
         )
 
@@ -412,10 +389,7 @@ class TestInterface(TestORCA):
             {
                 "mgt_ip": device_ip,
                 "name": ether_name,
-                "link_training": link_training,
                 "adv_speeds": set_adv_speed,
-                "speed": speed,
-                "fec": fec,
             },
         )
 

--- a/network/test/test_interface.py
+++ b/network/test/test_interface.py
@@ -253,7 +253,6 @@ class TestInterface(TestORCA):
 
         # changing the interface auto-negotiate and advertised-speed value
         response = self.put_req("device_interface_list", request_body)
-        print('=========',response.json())
         self.assertTrue(response.status_code == status.HTTP_200_OK)
 
         # verifying the auto-negotiate and advertised-speed value after changing the auto-negotiate value

--- a/network/test/test_interface.py
+++ b/network/test/test_interface.py
@@ -13,7 +13,6 @@ class TestInterface(TestORCA):
     """
 
     def test_interface_enable_config(self):
-
         device_ip = self.device_ips[0]
         ether_name = self.ether_names[1]
         response = self.get_req(
@@ -234,6 +233,9 @@ class TestInterface(TestORCA):
         # storing the auto-negotiate and advertised-speed
         pre_autoneg = response_1.json()["autoneg"]
         adv_speeds = response_1.json()["valid_speeds"]
+        speed = response_1.json()["speed"]
+        fec = response_1.json()["fec"]
+
 
         # setting the auto-negotiate to on or off with respective to previous auto-negotiate value
         # and creating request body
@@ -244,11 +246,14 @@ class TestInterface(TestORCA):
                 "name": ether_name,
                 "autoneg": set_autoneg,
                 "adv_speeds": adv_speeds,
+                "speed": speed,
+                "fec": fec
             },
         )
 
         # changing the interface auto-negotiate and advertised-speed value
         response = self.put_req("device_interface_list", request_body)
+        print('=========',response.json())
         self.assertTrue(response.status_code == status.HTTP_200_OK)
 
         # verifying the auto-negotiate and advertised-speed value after changing the auto-negotiate value
@@ -268,11 +273,13 @@ class TestInterface(TestORCA):
                 "name": ether_name,
                 "autoneg": pre_autoneg,
                 "adv_speeds": adv_speeds,
+                "speed": speed,
+                "fec": fec
             },
         )
         response = self.put_req("device_interface_list", request_body)
         self.assertTrue(response.status_code == status.HTTP_200_OK)
-        
+
         # verifying the auto-negotiate and advertised-speed value has set to default value
         self.assert_with_timeout_retry(
             lambda path, payload: self.get_req(path, payload),
@@ -282,7 +289,150 @@ class TestInterface(TestORCA):
             autoneg=pre_autoneg,
             status=status.HTTP_200_OK,
         )
+
+    def test_interface_training_link_config(self):
+        device_ip = self.device_ips[0]
+        ether_name = self.ether_names[1]
+
+        # getting details of a single interface for a particular ip
+        response_1 = self.get_req(
+            "device_interface_list", {"mgt_ip": device_ip, "name": ether_name}
+        )
+
+        # storing the lvariables and creating request body
+        pre_link_training = response_1.json()["link_training"]
+        adv_speeds = response_1.json()["valid_speeds"]
+        speed = response_1.json()["speed"]
+        fec = response_1.json()["fec"]
+
+        set_link_training = "on" if pre_link_training == "off" else "off"
+        request_body = (
+            {
+                "mgt_ip": device_ip,
+                "name": ether_name,
+                "link_training": set_link_training,
+                "adv_speeds": adv_speeds,
+                "speed": speed,
+                "fec": fec,
+            },
+        )
+
+        # changing the interface link training value to new value
+        response = self.put_req("device_interface_list", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        # verifying the link training value after changing the link training value
+        response_2 = self.assert_with_timeout_retry(
+            lambda path, payload: self.get_req(path, payload),
+            self.assertEqual,
+            "device_interface_list",
+            {"mgt_ip": device_ip, "name": ether_name},
+            link_training=set_link_training,
+            status=status.HTTP_200_OK,
+        )
         
+        # creating request to set the link training value to default value
+        request_body = (
+            {
+                "mgt_ip": device_ip,
+                "name": ether_name,
+                "link_training": pre_link_training,
+                "adv_speeds": adv_speeds,
+                "speed": speed,
+                "fec": fec,
+            },
+        )
+
+        # changing the interface link training value to default value
+        response = self.put_req("device_interface_list", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        # verifying the link training value has set to default value
+        self.assert_with_timeout_retry(
+            lambda path, payload: self.get_req(path, payload),
+            self.assertEqual,
+            "device_interface_list",
+            {"mgt_ip": device_ip, "name": ether_name},
+            link_training=pre_link_training,
+            status=status.HTTP_200_OK,
+        )
+
+    def test_interface_adv_speed_config(self):
+        device_ip = self.device_ips[0]
+        ether_name = self.ether_names[1]
+
+        # getting details of a single interface for a particular ip
+        response_1 = self.get_req(
+            "device_interface_list", {"mgt_ip": device_ip, "name": ether_name}
+        )
+
+        # crating variables to set the values
+        link_training = response_1.json()["link_training"]
+        adv_speeds = response_1.json()["adv_speeds"]
+        valid_speeds = response_1.json()["valid_speeds"]
+        speed = response_1.json()["speed"]
+        fec = response_1.json()["fec"]
+        
+        if adv_speeds == 'all': 
+            set_adv_speed = valid_speeds
+        else: 
+            set_adv_speed = ''
+        
+        request_body = (
+            {
+                "mgt_ip": device_ip,
+                "name": ether_name,
+                "link_training": link_training,
+                "adv_speeds": set_adv_speed,
+                "speed": speed,
+                "fec": fec,
+            },
+        )
+
+        # setting the and advertised-speed value with changed values
+        response = self.put_req("device_interface_list", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        # verifying the advertised-speed value after changing the advertised-speed with changed values
+        self.assert_with_timeout_retry(
+            lambda path, payload: self.get_req(path, payload),
+            self.assertEqual,
+            "device_interface_list",
+            {"mgt_ip": device_ip, "name": ether_name},
+            adv_speeds=set_adv_speed,
+            status=status.HTTP_200_OK,
+        )
+        
+        # variable to set back the advertised-speed to previous value
+        if adv_speeds == 'all':
+            set_adv_speed = ''
+        else: 
+            set_adv_speed = valid_speeds
+        
+        request_body = (
+            {
+                "mgt_ip": device_ip,
+                "name": ether_name,
+                "link_training": link_training,
+                "adv_speeds": set_adv_speed,
+                "speed": speed,
+                "fec": fec,
+            },
+        )
+
+        # setting the and advertised-speed value with default values
+        response = self.put_req("device_interface_list", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+        
+        # checking the advertised-speed value after changing the advertised-speed with default values
+        self.assert_with_timeout_retry(
+            lambda path, payload: self.get_req(path, payload),
+            self.assertEqual,
+            "device_interface_list",
+            {"mgt_ip": device_ip, "name": ether_name},
+            adv_speeds=set_adv_speed,
+            status=status.HTTP_200_OK,
+        )
 
     @unittest.skip("Randomly fails, to be debugged")
     def test_multiple_interfaces_config(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ djangorestframework = "^3.14.0"
 django-cors-headers = "^3.14.0"
 pytest = "^7.3.2"
 pytest-django = "^4.7.0"
-orca-nw-lib = "^1.3.11"
+orca-nw-lib = "^1.3.12"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
fixes [#62](https://github.com/STORDIS/orca_nw_lib/issues/62)

added functionality to configure the adv speed and link training with Test cases.