### PR TITLE
port channel chnages

### DIFF
--- a/log_manager/test/test_add_logs.py
+++ b/log_manager/test/test_add_logs.py
@@ -1,9 +1,6 @@
 from rest_framework.generics import get_object_or_404
-
 from log_manager.models import Logs
 from log_manager.serializers import LogSerializer
-from rest_framework.test import APITestCase
-
 from log_manager.test.test_common import TestCommon
 
 

--- a/log_manager/test/test_decorator.py
+++ b/log_manager/test/test_decorator.py
@@ -1,10 +1,6 @@
-import json
-
 from rest_framework import permissions
 from rest_framework.decorators import permission_classes, api_view
 from rest_framework.response import Response
-from rest_framework.test import APITestCase, APIRequestFactory
-
 from log_manager.decorators import log_request
 from log_manager.test.test_common import TestCommon
 

--- a/log_manager/test/test_decorator.py
+++ b/log_manager/test/test_decorator.py
@@ -13,14 +13,14 @@ from log_manager.test.test_common import TestCommon
 @permission_classes([permissions.AllowAny])
 @log_request
 def stub1(request):
-    return Response({"result": "testing"}, status=200)
+    return Response({"result": [{"message": "testing", "status": "success"}]}, status=200)
 
 
 @api_view(["GET", "POST"])
 @permission_classes([permissions.AllowAny])
 @log_request
 def stub2(request):
-    return Response({"result": ["test_1", "test_2", "test_3"]}, status=200)
+    return Response({"result": [{"message": "test_1", "status": "success"}, {"message": "test_2", "status": "success"}, {"message": "test_3", "status": "success"}]}, status=200)
 
 
 class TestDecorator(TestCommon):

--- a/log_manager/test/test_delete_logs.py
+++ b/log_manager/test/test_delete_logs.py
@@ -1,4 +1,3 @@
-from log_manager.models import Logs
 from log_manager.serializers import LogSerializer
 from log_manager.test.test_common import TestCommon
 

--- a/log_manager/test/test_get_logs.py
+++ b/log_manager/test/test_get_logs.py
@@ -1,5 +1,4 @@
 from log_manager.serializers import LogSerializer
-
 from log_manager.test.test_common import TestCommon
 
 

--- a/network/port_chnl.py
+++ b/network/port_chnl.py
@@ -8,12 +8,12 @@ from orca_nw_lib.port_chnl import (
     del_port_chnl,
     get_port_chnl_members,
     add_port_chnl_mem,
-    del_port_chnl_mem, remove_port_chnl_ip, remove_port_channel_vlan_member,
+    del_port_chnl_mem,
+    remove_port_chnl_ip,
+    remove_port_channel_vlan_member,
 )
-
 from log_manager.decorators import log_request
 from network.util import add_msg_to_list, get_failure_msg, get_success_msg
-
 from orca_nw_lib.port_chnl import add_port_chnl_vlan_members
 
 

--- a/network/port_chnl.py
+++ b/network/port_chnl.py
@@ -8,11 +8,13 @@ from orca_nw_lib.port_chnl import (
     del_port_chnl,
     get_port_chnl_members,
     add_port_chnl_mem,
-    del_port_chnl_mem,
+    del_port_chnl_mem, remove_port_chnl_ip, remove_port_channel_vlan_member,
 )
 
 from log_manager.decorators import log_request
 from network.util import add_msg_to_list, get_failure_msg, get_success_msg
+
+from orca_nw_lib.port_chnl import add_port_chnl_vlan_members
 
 
 @api_view(["GET", "PUT", "DELETE"])
@@ -82,12 +84,28 @@ def device_port_chnl_list(request):
                     req_data.get("lag_name"),
                     admin_status=req_data.get("admin_sts"),
                     mtu=int(req_data.get("mtu")) if "mtu" in req_data else None,
+                    static=req_data.get("static", None),
+                    min_links=int(req_data.get("min_links")) if "min_links" in req_data else None,
+                    fast_rate=req_data.get("fast_rate", None),
+                    description=req_data.get("description", None),
+                    fallback=req_data.get("fallback", None),
+                    graceful_shutdown_mode=req_data.get(
+                        "graceful_shutdown_mode", None
+                    ),
+                    ip_addr_with_prefix=req_data.get("ip_address", None)
                 )
                 if members := req_data.get("members"):
                     add_port_chnl_mem(
                         device_ip,
                         req_data.get("lag_name"),
                         members,
+                    )
+                if vlan_member := req_data.get("vlan_members"):
+                    add_port_chnl_vlan_members(
+                        device_ip=device_ip,
+                        chnl_name=req_data.get("lag_name"),
+                        access_vlan=vlan_member.get("access_valn"),
+                        trunk_vlans=vlan_member.get("trunk_vlans"),
                     )
                 add_msg_to_list(result, get_success_msg(request))
             except Exception as err:
@@ -129,4 +147,71 @@ def device_port_chnl_list(request):
         status=status.HTTP_200_OK
         if http_status
         else status.HTTP_500_INTERNAL_SERVER_ERROR,
+    )
+
+
+@api_view(["DELETE"])
+@log_request
+def remove_port_channel_ip_address(request):
+    result = []
+    http_status = True
+    if request.method == "DELETE":
+        req_data = request.data
+        device_ip = req_data.get("mgt_ip", "")
+        if not device_ip:
+            return Response(
+                {"status": "Required field device mgt_ip not found."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        chnl_name = req_data.get("lag_name", "")
+        if not chnl_name:
+            return Response(
+                {"status": "Required field device chnl_name not found."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        ip_addr = req_data.get("ip_address", None)
+        try:
+            remove_port_chnl_ip(device_ip, chnl_name, ip_addr)
+            add_msg_to_list(result, get_success_msg(request))
+        except Exception as err:
+            add_msg_to_list(result, get_failure_msg(err, request))
+            http_status = http_status and False
+    return Response(
+        {"result": result},
+        status=(
+            status.HTTP_200_OK if http_status else status.HTTP_500_INTERNAL_SERVER_ERROR
+        ),
+    )
+
+
+@api_view(["DELETE"])
+@log_request
+def remove_port_channel_member_vlan(request):
+    result = []
+    http_status = True
+    if request.method == "DELETE":
+        req_data = request.data
+        device_ip = req_data.get("mgt_ip", "")
+        if not device_ip:
+            return Response(
+                {"status": "Required field device mgt_ip not found."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        chnl_name = req_data.get("lag_name", "")
+        if not chnl_name:
+            return Response(
+                {"status": "Required field device chnl_name not found."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            remove_port_channel_vlan_member(device_ip, chnl_name)
+            add_msg_to_list(result, get_success_msg(request))
+        except Exception as err:
+            add_msg_to_list(result, get_failure_msg(err, request))
+            http_status = http_status and False
+    return Response(
+        {"result": result},
+        status=(
+            status.HTTP_200_OK if http_status else status.HTTP_500_INTERNAL_SERVER_ERROR
+        ),
     )

--- a/network/port_chnl.py
+++ b/network/port_chnl.py
@@ -100,6 +100,14 @@ def device_port_chnl_list(request):
                         req_data.get("lag_name"),
                         members,
                     )
+                add_msg_to_list(result, get_success_msg(request))
+            except Exception as err:
+                add_msg_to_list(result, get_failure_msg(err, request))
+                http_status = http_status and False
+
+            # some time add port channel vlan members might fail due to L3 configuration etc.
+            # hence try catch block and send additional failure message if it fails.
+            try:
                 if vlan_member := req_data.get("vlan_members"):
                     add_port_chnl_vlan_members(
                         device_ip=device_ip,
@@ -107,7 +115,6 @@ def device_port_chnl_list(request):
                         access_vlan=vlan_member.get("access_valn"),
                         trunk_vlans=vlan_member.get("trunk_vlans"),
                     )
-                add_msg_to_list(result, get_success_msg(request))
             except Exception as err:
                 add_msg_to_list(result, get_failure_msg(err, request))
                 http_status = http_status and False

--- a/network/test/test_port_chnl.py
+++ b/network/test/test_port_chnl.py
@@ -203,69 +203,211 @@ class TestPortChnl(TestORCA):
     def test_port_chnl_addtional_attributes(self):
         device_ip = self.device_ips[0]
         self.remove_mclag(device_ip)
+        port_channel = "PortChannel103"
+
+        #request body for adding port channel static as True
         request_body = {
             "mgt_ip": device_ip,
-            "lag_name": "PortChannel103",
+            "lag_name": port_channel,
+            "mtu": 9100,
+            "admin_status": "up",
+            "static": True,
+        }
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
+        self.perform_add_port_chnl([request_body])
+
+        response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
+
+        self.assertEqual(response.json()["static"], True)
+
+        # since static attribute cannot be updated delete port channel and then create it again
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
+        # request body for adding port channel static as False
+        request_body = {
+            "mgt_ip": device_ip,
+            "lag_name": port_channel,
             "mtu": 9100,
             "admin_status": "up",
             "static": False,
-            "min_links": 4,
-            "fast_rate": False,
-            "description": "test description channel 103",
+        }
+        self.perform_add_port_chnl([request_body])
+        response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
+
+        self.assertEqual(response.json()["static"], False)
+
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
+
+        # testing fallback attribute on port channel creation
+        request_body = {
+            "mgt_ip": device_ip,
+            "lag_name": port_channel,
+            "mtu": 9100,
+            "admin_status": "up",
+            "fallback": True,
+        }
+        self.perform_add_port_chnl([request_body])
+        response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
+        self.assertEqual(response.json()["fallback"], True)
+
+        # updating fallback attribute to False
+        request_body = {
+            "mgt_ip": device_ip,
+            "lag_name": port_channel,
+            "mtu": 9100,
+            "admin_status": "up",
             "fallback": False,
+        }
+        response = self.put_req("device_port_chnl", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
+        self.assertEqual(response.json()["fallback"], False)
+
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
+
+        # testing fast_rate attribute on port channel creation with True
+        request_body = {
+            "mgt_ip": device_ip,
+            "lag_name": port_channel,
+            "mtu": 9100,
+            "admin_status": "up",
+            "fast_rate": True,
+        }
+        self.perform_add_port_chnl([request_body])
+        response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
+        self.assertEqual(response.json()["fast_rate"], True)
+
+        # updating fast_rate attribute with False
+        request_body = {
+            "mgt_ip": device_ip,
+            "lag_name": port_channel,
+            "mtu": 9100,
+            "admin_status": "up",
+            "fast_rate": False,
+        }
+        response = self.put_req("device_port_chnl", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
+        self.assertEqual(response.json()["fast_rate"], False)
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
+
+        # Testing min_links attribute on port channel creation
+        request_body = {
+            "mgt_ip": device_ip,
+            "lag_name": port_channel,
+            "mtu": 9100,
+            "admin_status": "up",
+            "min_links": 2
+        }
+        self.perform_add_port_chnl([request_body])
+        response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
+        self.assertEqual(response.json()["min_links"], 2)
+
+        # updating min_links attribute with 4
+        request_body = {
+            "mgt_ip": device_ip,
+            "lag_name": port_channel,
+            "mtu": 9100,
+            "admin_status": "up",
+            "min_links": 4
+        }
+        response = self.put_req("device_port_chnl", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
+        self.assertEqual(response.json()["min_links"], 4)
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
+
+        # Test description attribute on port channel creation
+        request_body = {
+            "mgt_ip": device_ip,
+            "lag_name": port_channel,
+            "mtu": 9100,
+            "admin_status": "up",
+            "description": "test"
+        }
+        self.perform_add_port_chnl([request_body])
+        response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
+        self.assertEqual(response.json()["description"], "test")
+
+        # updating description attribute
+        request_body = {
+            "mgt_ip": device_ip,
+            "lag_name": port_channel,
+            "mtu": 9100,
+            "admin_status": "up",
+            "description": "test2"
+        }
+        response = self.put_req("device_port_chnl", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
+        self.assertEqual(response.json()["description"], "test2")
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
+
+        # Test graceful_shutdown_mode attribute on port channel creation
+        request_body = {
+            "mgt_ip": device_ip,
+            "lag_name": port_channel,
+            "mtu": 9100,
+            "admin_status": "up",
             "graceful_shutdown_mode": "Enable"
         }
-        self.perform_del_port_chnl({"mgt_ip": device_ip})
         self.perform_add_port_chnl([request_body])
-        self.assert_with_timeout_retry(
-            lambda path, payload: self.get_req(path, payload),
-            self.assertEqual,
-            "device_port_chnl",
-            request_body,
-            status=status.HTTP_200_OK,
-            static=False,
-            min_links=4,
-            fast_rate=False,
-            description="test description channel 103",
-            fallback=False,
-            graceful_shutdown_mode="Enable".upper()
-        )
-        self.perform_del_port_chnl({"mgt_ip": device_ip})
+        response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
+        self.assertEqual(response.json()["graceful_shutdown_mode"], "ENABLE")
+
+        # updating graceful_shutdown_mode attribute
+        request_body = {
+            "mgt_ip": device_ip,
+            "lag_name": port_channel,
+            "mtu": 9100,
+            "admin_status": "up",
+            "graceful_shutdown_mode": "Disable"
+        }
+        response = self.put_req("device_port_chnl", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
+        self.assertEqual(response.json()["graceful_shutdown_mode"], "DISABLE")
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
 
     def test_port_channel_ip(self):
         device_ip = self.device_ips[0]
         self.remove_mclag(device_ip)
-        ip_address = "192.10.10.9/24"
+        ip_address_1 = "192.10.10.9/24"
+        ip_address_2 = "192.11.10.9/24"
+        port_channel = "PortChannel103"
+        # Test ip_address attribute on port channel creation
         request_body = {
             "mgt_ip": device_ip,
-            "lag_name": "PortChannel103",
+            "lag_name": port_channel,
             "mtu": 9100,
             "admin_status": "up",
-            "ip_address": ip_address
+            "ip_address": ip_address_1
         }
-        self.perform_del_port_chnl({"mgt_ip": device_ip})
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
         self.perform_add_port_chnl([request_body])
-        self.assert_with_timeout_retry(
-            lambda path, payload: self.get_req(path, payload),
-            self.assertEqual,
-            "device_port_chnl",
-            request_body,
-            status=status.HTTP_200_OK,
-            ip_address=ip_address
-        )
+        response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
+        self.assertEqual(response.json()["ip_address"], ip_address_1)
+
+        # updating ip_address attribute
+        request_body = {
+            "mgt_ip": device_ip,
+            "lag_name": port_channel,
+            "mtu": 9100,
+            "admin_status": "up",
+            "ip_address": ip_address_2
+        }
+        response = self.put_req("device_port_chnl", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
+        self.assertEqual(response.json()["ip_address"], ip_address_2)
+
+        # Testing delete ip_address
         del_resp = self.del_req("port_channel_ip_remove", {
-            "mgt_ip": device_ip, "lag_name": "PortChannel103", "ip_address": ip_address
+            "mgt_ip": device_ip, "lag_name": port_channel, "ip_address": ip_address_2
         })
         self.assertEqual(del_resp.status_code, status.HTTP_200_OK)
-        self.assert_with_timeout_retry(
-            lambda path, payload: self.get_req(path, payload),
-            self.assertEqual,
-            "device_port_chnl",
-            {"mgt_ip": device_ip, "lag_name": "PortChannel103"},
-            status=status.HTTP_200_OK,
-            ip_address=None
-        )
-        self.perform_del_port_chnl({"mgt_ip": device_ip})
+        response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
+        self.assertEqual(response.json()["ip_address"], None)
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
 
     def test_port_channel_vlan_members(self):
         # Creating vlan for testing
@@ -274,6 +416,9 @@ class TestPortChnl(TestORCA):
         vlan_1_id = 4
         vlan_2_name = "Vlan5"
         vlan_2_id = 5
+        vlan_3_name = "Vlan6"
+        vlan_3_id = 6
+        port_channel = "PortChannel103"
         req_payload = [
             {
                 "mgt_ip": device_ip,
@@ -291,6 +436,14 @@ class TestPortChnl(TestORCA):
                 "enabled": False,
                 "description": "Test_Vlan1",
             },
+            {
+                "mgt_ip": device_ip,
+                "name": vlan_3_name,
+                "vlanid": vlan_3_id,
+                "mtu": 9000,
+                "enabled": False,
+                "description": "Test_Vlan1",
+            },
         ]
 
         response = self.put_req(
@@ -298,9 +451,24 @@ class TestPortChnl(TestORCA):
             req_payload,
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Testing whether vlans are added or not
+        response = self.get_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["vlanid"], vlan_1_id)
+        self.assertEqual(response.json()["name"], vlan_1_name)
+        response = self.get_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_2_name})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["vlanid"], vlan_2_id)
+        self.assertEqual(response.json()["name"], vlan_2_name)
+        response = self.get_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_3_name})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["vlanid"], vlan_3_id)
+        self.assertEqual(response.json()["name"], vlan_3_name)
+
         request_body = {
             "mgt_ip": device_ip,
-            "lag_name": "PortChannel103",
+            "lag_name": port_channel,
             "mtu": 9100,
             "admin_status": "up",
             "vlan_members": {
@@ -308,7 +476,7 @@ class TestPortChnl(TestORCA):
                 "access_valn": vlan_2_id
             }
         }
-        self.perform_del_port_chnl({"mgt_ip": device_ip})
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
         self.perform_add_port_chnl([request_body])
 
         get_response = self.get_req("device_port_chnl", request_body, )
@@ -317,22 +485,48 @@ class TestPortChnl(TestORCA):
         self.assertEqual(members.get("trunk_vlans"), [vlan_1_id])
         self.assertEqual(members.get("access_vlan"), vlan_2_id)
 
+        # Test updating vlan members
+        request_body = {
+            "mgt_ip": device_ip,
+            "lag_name": port_channel,
+            "vlan_members": {
+                "trunk_vlans": [vlan_1_id, vlan_3_id],
+                "access_valn": vlan_2_id
+            }
+        }
+        member_update_response = self.put_req("device_port_chnl", req_json=request_body)
+        self.assertEqual(member_update_response.status_code, status.HTTP_200_OK)
+        get_response = self.get_req("device_port_chnl", request_body, )
+        self.assertEqual(get_response.status_code, status.HTTP_200_OK)
+        members = get_response.json().get("vlan_members")
+        self.assertEqual(members.get("trunk_vlans"), [vlan_1_id, vlan_3_id])
+        self.assertEqual(members.get("access_vlan"), vlan_2_id)
+
         #deleting portchannel vlan members
         member_delete_response = self.del_req("port_chnl_vlan_member_remove", req_json=request_body)
-        print(member_delete_response.content)
         self.assertEqual(member_delete_response.status_code, status.HTTP_200_OK)
 
-        get_response = self.get_req("device_port_chnl", request_body, )
+        get_response = self.get_req("device_port_chnl", request_body)
         self.assertEqual(get_response.status_code, status.HTTP_200_OK)
         members = get_response.json().get("vlan_members")
         self.assertEqual(members, {})
 
-        self.perform_del_port_chnl({"mgt_ip": device_ip})
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
         response = self.del_req(
             "vlan_config", {"mgt_ip": device_ip, "name": vlan_2_name}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.get_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_2_name})
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         response = self.del_req(
             "vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name}
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.get_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name})
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        response = self.del_req(
+            "vlan_config", {"mgt_ip": device_ip, "name": vlan_3_name}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.get_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_3_name})
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)

--- a/network/test/test_port_chnl.py
+++ b/network/test/test_port_chnl.py
@@ -200,7 +200,7 @@ class TestPortChnl(TestORCA):
         self.perform_del_port_chnl(request_body)
         self.perform_del_port_chnl(request_body_2)
 
-    def test_port_chnl_addtional_attributes(self):
+    def test_port_chnl_static_attribute(self):
         device_ip = self.device_ips[0]
         self.remove_mclag(device_ip)
         port_channel = "PortChannel103"
@@ -215,9 +215,7 @@ class TestPortChnl(TestORCA):
         }
         self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
         self.perform_add_port_chnl([request_body])
-
         response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
-
         self.assertEqual(response.json()["static"], True)
 
         # since static attribute cannot be updated delete port channel and then create it again
@@ -230,14 +228,18 @@ class TestPortChnl(TestORCA):
             "admin_status": "up",
             "static": False,
         }
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
         self.perform_add_port_chnl([request_body])
         response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
-
         self.assertEqual(response.json()["static"], False)
+        self.perform_del_port_chnl(request_body)
 
-        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
+    def test_port_chnl_fallback_attribute(self):
+        device_ip = self.device_ips[0]
+        self.remove_mclag(device_ip)
+        port_channel = "PortChannel103"
 
-        # testing fallback attribute on port channel creation
+        # testing fallback attribute on port channel with True
         request_body = {
             "mgt_ip": device_ip,
             "lag_name": port_channel,
@@ -261,8 +263,12 @@ class TestPortChnl(TestORCA):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
         self.assertEqual(response.json()["fallback"], False)
+        self.perform_del_port_chnl(request_body)
 
-        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
+    def test_port_chnl_fast_rate_attribute(self):
+        device_ip = self.device_ips[0]
+        self.remove_mclag(device_ip)
+        port_channel = "PortChannel103"
 
         # testing fast_rate attribute on port channel creation with True
         request_body = {
@@ -276,7 +282,7 @@ class TestPortChnl(TestORCA):
         response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
         self.assertEqual(response.json()["fast_rate"], True)
 
-        # updating fast_rate attribute with False
+        # updating fast_rate attribute to False
         request_body = {
             "mgt_ip": device_ip,
             "lag_name": port_channel,
@@ -288,9 +294,14 @@ class TestPortChnl(TestORCA):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
         self.assertEqual(response.json()["fast_rate"], False)
-        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
+        self.perform_del_port_chnl(request_body)
 
-        # Testing min_links attribute on port channel creation
+    def test_port_chnl_min_links_attribute(self):
+        device_ip = self.device_ips[0]
+        self.remove_mclag(device_ip)
+        port_channel = "PortChannel103"
+
+        # testing min_links attribute on port channel creation
         request_body = {
             "mgt_ip": device_ip,
             "lag_name": port_channel,
@@ -314,9 +325,14 @@ class TestPortChnl(TestORCA):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
         self.assertEqual(response.json()["min_links"], 4)
-        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
+        self.perform_del_port_chnl(request_body)
 
-        # Test description attribute on port channel creation
+    def test_port_chnl_description_attribute(self):
+        device_ip = self.device_ips[0]
+        self.remove_mclag(device_ip)
+        port_channel = "PortChannel103"
+
+        # testing description attribute on port channel creation
         request_body = {
             "mgt_ip": device_ip,
             "lag_name": port_channel,
@@ -340,7 +356,12 @@ class TestPortChnl(TestORCA):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
         self.assertEqual(response.json()["description"], "test2")
-        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
+        self.perform_del_port_chnl(request_body)
+
+    def test_port_chnl_grace_full_shutdown_attributes(self):
+        device_ip = self.device_ips[0]
+        self.remove_mclag(device_ip)
+        port_channel = "PortChannel103"
 
         # Test graceful_shutdown_mode attribute on port channel creation
         request_body = {

--- a/network/urls.py
+++ b/network/urls.py
@@ -15,6 +15,8 @@ urlpatterns = [
         "interfaces", interface.device_interfaces_list, name="device_interface_list"
     ),
     re_path("port_chnls", port_chnl.device_port_chnl_list, name="device_port_chnl"),
+    path("port_chnl_ip_remove", port_chnl.remove_port_channel_ip_address, name="port_channel_ip_remove"),
+    path("port_chnl_vlan_member_remove", port_chnl.remove_port_channel_member_vlan, name="port_chnl_vlan_member_remove"),
     re_path("mclags", mclag.device_mclag_list, name="device_mclag_list"),
     re_path("bgp", bgp.device_bgp_global, name="bgp_global"),
     re_path("nbrs", bgp.bgp_nbr_config, name="bgp_nbr"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ djangorestframework = "^3.14.0"
 django-cors-headers = "^3.14.0"
 pytest = "^7.3.2"
 pytest-django = "^4.7.0"
-orca-nw-lib = "^1.3.12"
+orca-nw-lib = "^1.3.13"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
Fixed issues:

- Add property “static” (configurable)
- fallback (configurable) default false.
- fast-rate (configurable) default false.
- min-links (configurable) possible values 1-32 default 1.
- description (configurable) default false.
- graceful_shutdown_mode (configurable) default ENABLE
- Add member vlan to portchannel. (Currently only Ethernets can be PortChannel members)
- Assign/Remove IP to portchannel. (IP validation to be performed on UI and backend)
- Tests for config verification of above parameters.

Unresolved issues:

- UI - Respective Display and Config Operations need to be supported on UI. The "name" field on the UI is respective to "static" field above in the backend. On the UI "name" field can be renamed to "protocol name" and if value of "static" is true the "protocol name" should be "lacp" else "protocol name" should be "none".

This issue will be fixed by @vivek-metricdust 