### PR TITLE
build: refactor Dockerfile to make use of Docker's build cache, cutting down build times

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
 FROM ubuntu:22.04
 RUN apt-get update
-WORKDIR /orca_backend
-COPY . .
 RUN apt install python3 -y
 RUN apt install python3-pip -y
 RUN pip install --upgrade pip
 RUN pip install poetry
+WORKDIR /orca_backend
+
+COPY ./pyproject.toml .
 RUN poetry config virtualenvs.create false \
     && poetry install --no-interaction
+
+COPY . .
+
 ## Check if ORCASK app is present, if yes install its dependencies.
 RUN test -d ORCASK \
     && cd ORCASK \


### PR DESCRIPTION
Hello,

you can leverage Docker's build cache a lot more efficiently, if you split up and reorder the commands up a tiny bit.
This considerably cuts down build times, if you frequently rebuild the same image.
More info here:
https://docs.docker.com/build/cache/#optimizing-how-you-use-the-build-cache

The proposed changes do exactly that :-)

I previously needed about 60-70s for each single build run, in my tests, because it was **always** reinstalling the python dependencies.
After changing the order to make use of the build cache, this cut it down to approx 60-70s for the initial build and each subsequent build, was then took only approx. 3s


btw: the Docker build can be further optimized, by e.g. switching from a ubuntu-base image to e.g. one of the images from Python:
https://hub.docker.com/_/python
Then even the initial build should be a lot faster as well (and the image size will be smaller as well)