### PR TITLE
 Port-Group speed updates and Interface valid-speeds issue. #67

### DIFF
--- a/network/port_group.py
+++ b/network/port_group.py
@@ -6,7 +6,7 @@ from orca_nw_lib.common import Speed
 from orca_nw_lib.portgroup import (
     get_port_groups,
     get_port_group_members,
-    set_port_group_speed,
+    set_port_group_speed, get_port_group_of_interface,
 )
 
 from log_manager.decorators import log_request
@@ -114,4 +114,34 @@ def port_group_members(request):
             else Response(
                 {"status": "No port group members found."}, status.HTTP_404_NOT_FOUND
             )
+        )
+
+
+@api_view(
+    [
+        "GET",
+    ]
+)
+def port_group_from_intfc_name(request):
+    """
+    This function handles the API view for listing port group members.
+    """
+    if request.method == "GET":
+        device_ip = request.GET.get("mgt_ip", "")
+        if not device_ip:
+            return Response(
+                {"status": "Required field device mgt_ip not found."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        intf_name = request.GET.get("intf_name", "")
+        if not intf_name:
+            return Response(
+                {"status": "Required field intf_name not found."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        data = get_port_group_of_interface(device_ip, intf_name)
+        return (
+            Response(data, status.HTTP_200_OK)
+            if data
+            else Response({"status": "No port group found for the interface."}, status.HTTP_204_NO_CONTENT)
         )

--- a/network/test/test_port_group.py
+++ b/network/test/test_port_group.py
@@ -183,3 +183,80 @@ class TestPortGroup(TestORCA):
                     status=status.HTTP_200_OK,
                     speed=pg_1["speed"],
                 )
+
+    def test_port_group_interfaces_valid_speed_update(self):
+        """
+        Test port group interfaces valid speed update.
+        """
+        device_ip = self.device_ips[0]
+        request_body = {"mgt_ip": device_ip, "port_group_id": "1"}
+
+        ## Simply delete all port channels as if an interface which is member of a port channel as well,
+        # speed config will fail.
+        self.perform_del_port_chnl({"mgt_ip": device_ip})
+
+        # Get current speed
+        response = self.get_req("port_groups", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+        port_groups = response.json()
+
+        # Test Port Group Speed with 25G
+        request_body["speed"] = "SPEED_25GB"
+
+        self.assert_with_timeout_retry(
+            lambda path, data: self.put_req(path, data),
+            self.assertTrue,
+            "port_groups",
+            request_body,
+            status=status.HTTP_200_OK,
+        )
+        # Confirm port group change
+        self.assert_with_timeout_retry(
+            lambda path, data: self.get_req(path, data),
+            self.assertTrue,
+            "port_groups",
+            request_body,
+            status=status.HTTP_200_OK,
+            speed=request_body["speed"],
+        )
+        # Confirm speed changes on all member interfaces
+        for mem_if in response.json().get("mem_intfs"):
+            self.assert_with_timeout_retry(
+                lambda path, data: self.get_req(path, data),
+                self.assertEqual,
+                "device_interface_list",
+                {"mgt_ip": device_ip, "name": mem_if},
+                status=status.HTTP_200_OK,
+                speed=request_body["speed"],
+                valid_speeds="25000",
+            )
+
+        # change speed to 10GB
+        request_body["speed"] = "SPEED_10GB"
+        self.assert_with_timeout_retry(
+            lambda path, data: self.put_req(path, data),
+            self.assertTrue,
+            "port_groups",
+            request_body,
+            status=status.HTTP_200_OK,
+        )
+        # Confirm port group change
+        self.assert_with_timeout_retry(
+            lambda path, data: self.get_req(path, data),
+            self.assertTrue,
+            "port_groups",
+            request_body,
+            status=status.HTTP_200_OK,
+            speed=request_body["speed"],
+        )
+        # Confirm speed changes on all member interfaces
+        for mem_if in response.json().get("mem_intfs"):
+            self.assert_with_timeout_retry(
+                lambda path, data: self.get_req(path, data),
+                self.assertEqual,
+                "device_interface_list",
+                {"mgt_ip": device_ip, "name": mem_if},
+                status=status.HTTP_200_OK,
+                speed=request_body["speed"],
+                valid_speeds="10000,1000",
+            )

--- a/network/urls.py
+++ b/network/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
     re_path("config_mclag_fast_convergence", mclag.config_mclag_fast_convergence, name="config_mclag_fast_convergence"),
     re_path("bgp", bgp.device_bgp_global, name="bgp_global"),
     re_path("nbrs", bgp.bgp_nbr_config, name="bgp_nbr"),
+    re_path("group_from_intfc", port_group.port_group_from_intfc_name, name="group_from_intfc"),
     re_path("group_mem", port_group.port_group_members, name="port_group_members"),
     re_path("groups", port_group.port_groups, name="port_groups"),
     re_path("gateway_mac", mclag.mclag_gateway_mac, name="mclag_gateway_mac"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ djangorestframework = "^3.14.0"
 django-cors-headers = "^3.14.0"
 pytest = "^7.3.2"
 pytest-django = "^4.7.0"
-orca-nw-lib = "^1.3.15"
+orca-nw-lib = "^1.3.16"
 packaging = "^23.2"# Because of langchain dependencies in ORCASK, packaging should not be greater than 23.y.z.
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ djangorestframework = "^3.14.0"
 django-cors-headers = "^3.14.0"
 pytest = "^7.3.2"
 pytest-django = "^4.7.0"
-orca-nw-lib = "^1.3.16"
+orca-nw-lib = "^1.3.17"
 packaging = "^23.2"# Because of langchain dependencies in ORCASK, packaging should not be greater than 23.y.z.
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Fixes https://github.com/STORDIS/orca_nw_lib/issues/67

issue:

If port group speed is set to 25G , all interface in the port-group are updated to have the speed 25G, but the valid speeds and adv-speed set is still 1G and 10G which is not correct.

The correct behaviour would be if port-group speed is updated, after receving the port-group update via gNMI subscription make an additional gnmi get to update the valid_speeds field for interface at sonic-port:sonic-port/PORT/PORT_LIST={interface_name}.

Write test case for above.

Fixes:

Added interface discovery on speed update.
Added test cases to validate. valid speeds update.