### PR TITLE
Advance config options for PortChannels. #52

### DIFF
--- a/network/port_chnl.py
+++ b/network/port_chnl.py
@@ -1,4 +1,6 @@
 """ Network Port Channel API. """
+import traceback
+
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
 from rest_framework import status
@@ -112,7 +114,7 @@ def device_port_chnl_list(request):
                     add_port_chnl_vlan_members(
                         device_ip=device_ip,
                         chnl_name=req_data.get("lag_name"),
-                        access_vlan=vlan_member.get("access_valn"),
+                        access_vlan=vlan_member.get("access_vlan"),
                         trunk_vlans=vlan_member.get("trunk_vlans"),
                     )
             except Exception as err:

--- a/network/test/test_common.py
+++ b/network/test/test_common.py
@@ -80,6 +80,7 @@ class TestORCA(APITestCase):
                             If the response status code is not 204 NO CONTENT.
         """
         response = self.del_req("device_port_chnl", request_body)
+        print(response.content)
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(

--- a/network/test/test_common.py
+++ b/network/test/test_common.py
@@ -80,7 +80,6 @@ class TestORCA(APITestCase):
                             If the response status code is not 204 NO CONTENT.
         """
         response = self.del_req("device_port_chnl", request_body)
-        print(response.content)
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(

--- a/network/test/test_port_chnl.py
+++ b/network/test/test_port_chnl.py
@@ -580,7 +580,11 @@ class TestPortChnl(TestORCA):
         response = self.get_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_3_name})
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
-    def test_port_channel_vlan_members_in_series(self):
+    def test_port_channel_vlan_members_in_series_with_dot(self):
+        """
+        Test case for adding vlan members in port channel in series with hyphen.
+        eg . {trunk_vlans: [1, "3..5"], access_vlan: 4}
+        """
         device_ip = self.device_ips[0]
         self.remove_mclag(device_ip)
         port_channel = "PortChannel103"
@@ -622,7 +626,6 @@ class TestPortChnl(TestORCA):
             "vlan_config",
             req_payload,
         )
-        print("---------", response.content)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # Testing whether vlans are added or not
@@ -657,6 +660,125 @@ class TestPortChnl(TestORCA):
         self.perform_add_port_chnl(request_body)
         response = self.get_req("device_port_chnl", request_body)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json().get("lag_name"), port_channel)
+        self.assertEqual(response.json().get("mtu"), 9100)
+        self.assertEqual(response.json().get("admin_sts"), "up")
+        members = response.json().get("vlan_members")
+        self.assertEqual(members.get("trunk_vlans"), [vlan_1_id, vlan_2_id, vlan_3_id])
+        self.assertEqual(members.get("access_vlan"), vlan_2_id)
+
+        # deleting portchannel vlan members
+        member_delete_response = self.del_req("port_chnl_vlan_member_remove", req_json=request_body)
+        self.assertEqual(member_delete_response.status_code, status.HTTP_200_OK)
+
+        get_response = self.get_req("device_port_chnl", request_body)
+        self.assertEqual(get_response.status_code, status.HTTP_200_OK)
+        members = get_response.json().get("vlan_members")
+        self.assertEqual(members, {})
+
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
+        response = self.del_req(
+            "vlan_config", {"mgt_ip": device_ip, "name": vlan_2_name}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.get_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_2_name})
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        response = self.del_req(
+            "vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.get_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name})
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        response = self.del_req(
+            "vlan_config", {"mgt_ip": device_ip, "name": vlan_3_name}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.get_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_3_name})
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_port_channel_vlan_members_in_series_with_hyphen(self):
+        """
+        Test case for adding vlan members in port channel in series with hyphen.
+        eg . {trunk_vlans: [1, "3-5"], access_vlan: 4}
+        """
+        device_ip = self.device_ips[0]
+        self.remove_mclag(device_ip)
+        port_channel = "PortChannel103"
+        vlan_1_name = "Vlan3"
+        vlan_1_id = 3
+        vlan_2_name = "Vlan4"
+        vlan_2_id = 4
+        vlan_3_name = "Vlan5"
+        vlan_3_id = 5
+
+        req_payload = [
+            {
+                "mgt_ip": device_ip,
+                "name": vlan_1_name,
+                "vlanid": vlan_1_id,
+                "mtu": 9000,
+                "enabled": False,
+                "description": "Test_Vlan1",
+            },
+            {
+                "mgt_ip": device_ip,
+                "name": vlan_2_name,
+                "vlanid": vlan_2_id,
+                "mtu": 9000,
+                "enabled": False,
+                "description": "Test_Vlan2",
+            },
+            {
+                "mgt_ip": device_ip,
+                "name": vlan_3_name,
+                "vlanid": vlan_3_id,
+                "mtu": 9000,
+                "enabled": False,
+                "description": "Test_Vlan3",
+            },
+        ]
+
+        response = self.put_req(
+            "vlan_config",
+            req_payload,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Testing whether vlans are added or not
+        response = self.get_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["vlanid"], vlan_1_id)
+        self.assertEqual(response.json()["name"], vlan_1_name)
+        response = self.get_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_2_name})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["vlanid"], vlan_2_id)
+        self.assertEqual(response.json()["name"], vlan_2_name)
+        response = self.get_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_3_name})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["vlanid"], vlan_3_id)
+        self.assertEqual(response.json()["name"], vlan_3_name)
+
+        request_body = {
+            "mgt_ip": device_ip,
+            "lag_name": port_channel,
+            "mtu": 9100,
+            "admin_status": "up",
+            "vlan_members": {
+                "trunk_vlans": [f"{vlan_1_id}-{vlan_3_id}"],
+                "access_vlan": vlan_2_id
+            }
+        }
+
+        # cleaning up port channel if it exists
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
+
+        # adding port channel
+        self.perform_add_port_chnl(request_body)
+        response = self.get_req("device_port_chnl", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json().get("lag_name"), port_channel)
+        self.assertEqual(response.json().get("mtu"), 9100)
+        self.assertEqual(response.json().get("admin_sts"), "up")
         members = response.json().get("vlan_members")
         self.assertEqual(members.get("trunk_vlans"), [vlan_1_id, vlan_2_id, vlan_3_id])
         self.assertEqual(members.get("access_vlan"), vlan_2_id)

--- a/network/test/test_port_chnl.py
+++ b/network/test/test_port_chnl.py
@@ -247,6 +247,11 @@ class TestPortChnl(TestORCA):
             "admin_status": "up",
             "fallback": True,
         }
+
+        # cleaning up port channel if it exists
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
+
+        # adding port channel
         self.perform_add_port_chnl([request_body])
         response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
         self.assertEqual(response.json()["fallback"], True)
@@ -278,6 +283,10 @@ class TestPortChnl(TestORCA):
             "admin_status": "up",
             "fast_rate": True,
         }
+        # cleaning up port channel if it exists
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
+
+        # adding port channel
         self.perform_add_port_chnl([request_body])
         response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
         self.assertEqual(response.json()["fast_rate"], True)
@@ -309,6 +318,10 @@ class TestPortChnl(TestORCA):
             "admin_status": "up",
             "min_links": 2
         }
+        # cleaning up port channel if it exists
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
+
+        # adding port channel
         self.perform_add_port_chnl([request_body])
         response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
         self.assertEqual(response.json()["min_links"], 2)
@@ -340,6 +353,10 @@ class TestPortChnl(TestORCA):
             "admin_status": "up",
             "description": "test"
         }
+        # cleaning up port channel if it exists
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
+
+        # adding port channel
         self.perform_add_port_chnl([request_body])
         response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
         self.assertEqual(response.json()["description"], "test")
@@ -371,6 +388,10 @@ class TestPortChnl(TestORCA):
             "admin_status": "up",
             "graceful_shutdown_mode": "Enable"
         }
+        # cleaning up port channel if it exists
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
+
+        # adding port channel
         self.perform_add_port_chnl([request_body])
         response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
         self.assertEqual(response.json()["graceful_shutdown_mode"], "ENABLE")
@@ -403,7 +424,11 @@ class TestPortChnl(TestORCA):
             "admin_status": "up",
             "ip_address": ip_address_1
         }
+
+        # cleaning up port channel if it exists
         self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
+
+        # adding port channel
         self.perform_add_port_chnl([request_body])
         response = self.get_req("device_port_chnl", {"mgt_ip": device_ip, "lag_name": port_channel})
         self.assertEqual(response.json()["ip_address"], ip_address_1)
@@ -494,10 +519,13 @@ class TestPortChnl(TestORCA):
             "admin_status": "up",
             "vlan_members": {
                 "trunk_vlans": [vlan_1_id],
-                "access_valn": vlan_2_id
+                "access_vlan": vlan_2_id
             }
         }
+        # cleaning up port channel if it exists
         self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
+
+        # adding port channel
         self.perform_add_port_chnl([request_body])
 
         get_response = self.get_req("device_port_chnl", request_body, )
@@ -512,7 +540,7 @@ class TestPortChnl(TestORCA):
             "lag_name": port_channel,
             "vlan_members": {
                 "trunk_vlans": [vlan_1_id, vlan_3_id],
-                "access_valn": vlan_2_id
+                "access_vlan": vlan_2_id
             }
         }
         member_update_response = self.put_req("device_port_chnl", req_json=request_body)
@@ -524,6 +552,116 @@ class TestPortChnl(TestORCA):
         self.assertEqual(members.get("access_vlan"), vlan_2_id)
 
         #deleting portchannel vlan members
+        member_delete_response = self.del_req("port_chnl_vlan_member_remove", req_json=request_body)
+        self.assertEqual(member_delete_response.status_code, status.HTTP_200_OK)
+
+        get_response = self.get_req("device_port_chnl", request_body)
+        self.assertEqual(get_response.status_code, status.HTTP_200_OK)
+        members = get_response.json().get("vlan_members")
+        self.assertEqual(members, {})
+
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
+        response = self.del_req(
+            "vlan_config", {"mgt_ip": device_ip, "name": vlan_2_name}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.get_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_2_name})
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        response = self.del_req(
+            "vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.get_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name})
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        response = self.del_req(
+            "vlan_config", {"mgt_ip": device_ip, "name": vlan_3_name}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.get_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_3_name})
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_port_channel_vlan_members_in_series(self):
+        device_ip = self.device_ips[0]
+        self.remove_mclag(device_ip)
+        port_channel = "PortChannel103"
+        vlan_1_name = "Vlan3"
+        vlan_1_id = 3
+        vlan_2_name = "Vlan4"
+        vlan_2_id = 4
+        vlan_3_name = "Vlan5"
+        vlan_3_id = 5
+
+        req_payload = [
+            {
+                "mgt_ip": device_ip,
+                "name": vlan_1_name,
+                "vlanid": vlan_1_id,
+                "mtu": 9000,
+                "enabled": False,
+                "description": "Test_Vlan1",
+            },
+            {
+                "mgt_ip": device_ip,
+                "name": vlan_2_name,
+                "vlanid": vlan_2_id,
+                "mtu": 9000,
+                "enabled": False,
+                "description": "Test_Vlan2",
+            },
+            {
+                "mgt_ip": device_ip,
+                "name": vlan_3_name,
+                "vlanid": vlan_3_id,
+                "mtu": 9000,
+                "enabled": False,
+                "description": "Test_Vlan3",
+            },
+        ]
+
+        response = self.put_req(
+            "vlan_config",
+            req_payload,
+        )
+        print("---------", response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Testing whether vlans are added or not
+        response = self.get_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["vlanid"], vlan_1_id)
+        self.assertEqual(response.json()["name"], vlan_1_name)
+        response = self.get_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_2_name})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["vlanid"], vlan_2_id)
+        self.assertEqual(response.json()["name"], vlan_2_name)
+        response = self.get_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_3_name})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["vlanid"], vlan_3_id)
+        self.assertEqual(response.json()["name"], vlan_3_name)
+
+        request_body = {
+            "mgt_ip": device_ip,
+            "lag_name": port_channel,
+            "mtu": 9100,
+            "admin_status": "up",
+            "vlan_members": {
+                "trunk_vlans": [f"{vlan_1_id}..{vlan_3_id}"],
+                "access_vlan": vlan_2_id
+            }
+        }
+
+        # cleaning up port channel if it exists
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel})
+
+        # adding port channel
+        self.perform_add_port_chnl(request_body)
+        response = self.get_req("device_port_chnl", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        members = response.json().get("vlan_members")
+        self.assertEqual(members.get("trunk_vlans"), [vlan_1_id, vlan_2_id, vlan_3_id])
+        self.assertEqual(members.get("access_vlan"), vlan_2_id)
+
+        # deleting portchannel vlan members
         member_delete_response = self.del_req("port_chnl_vlan_member_remove", req_json=request_body)
         self.assertEqual(member_delete_response.status_code, status.HTTP_200_OK)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ djangorestframework = "^3.14.0"
 django-cors-headers = "^3.14.0"
 pytest = "^7.3.2"
 pytest-django = "^4.7.0"
-orca-nw-lib = "^1.3.16"
+orca-nw-lib = "^1.3.17"
 packaging = "^23.2"# Because of langchain dependencies in ORCASK, packaging should not be greater than 23.y.z.
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ djangorestframework = "^3.14.0"
 django-cors-headers = "^3.14.0"
 pytest = "^7.3.2"
 pytest-django = "^4.7.0"
-orca-nw-lib = "^1.3.17"
+orca-nw-lib = "^1.3.18"
 packaging = "^23.2"# Because of langchain dependencies in ORCASK, packaging should not be greater than 23.y.z.
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION

Issues: 

- the backednd will prompt the error i.e, - Couldn't discover Port Channel on device 10.10.229.58, Reason: invalid literal for int() with base 10: '2-4'
- sometimes the response is just the trunk vlans only

Fixes:

- resolved issue while adding to db using function - format_and_get_trunk_vlans in utils.py 
- added test cases test_port_channel_vlan_members_in_series.
- fixes typo issue for acces_vlan.