### PR TITLE
Mclag domain additional configuration. - b - #63

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,29 @@
 {
-    "python.testing.pytestArgs": [
+    "python.testing.unittestArgs": [
         "network/test",
+        "ORCASK/test",
         "authentication/test"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "workbench.colorCustomizations": {
+        "activityBar.activeBackground": "#3333ff",
+        "activityBar.background": "#3333ff",
+        "activityBar.foreground": "#e7e7e7",
+        "activityBar.inactiveForeground": "#e7e7e799",
+        "activityBarBadge.background": "#600000",
+        "activityBarBadge.foreground": "#e7e7e7",
+        "commandCenter.border": "#e7e7e799",
+        "sash.hoverBorder": "#3333ff",
+        "statusBar.background": "#0000ff",
+        "statusBar.foreground": "#e7e7e7",
+        "statusBarItem.hoverBackground": "#3333ff",
+        "statusBarItem.remoteBackground": "#0000ff",
+        "statusBarItem.remoteForeground": "#e7e7e7",
+        "titleBar.activeBackground": "#0000ff",
+        "titleBar.activeForeground": "#e7e7e7",
+        "titleBar.inactiveBackground": "#0000ff99",
+        "titleBar.inactiveForeground": "#e7e7e799"
+    },
+    "peacock.remoteColor": "blue"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,29 +1,8 @@
 {
-    "python.testing.unittestArgs": [
+    "python.testing.pytestArgs": [
         "network/test",
-        "ORCASK/test",
         "authentication/test"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true,
-    "workbench.colorCustomizations": {
-        "activityBar.activeBackground": "#3333ff",
-        "activityBar.background": "#3333ff",
-        "activityBar.foreground": "#e7e7e7",
-        "activityBar.inactiveForeground": "#e7e7e799",
-        "activityBarBadge.background": "#600000",
-        "activityBarBadge.foreground": "#e7e7e7",
-        "commandCenter.border": "#e7e7e799",
-        "sash.hoverBorder": "#3333ff",
-        "statusBar.background": "#0000ff",
-        "statusBar.foreground": "#e7e7e7",
-        "statusBarItem.hoverBackground": "#3333ff",
-        "statusBarItem.remoteBackground": "#0000ff",
-        "statusBarItem.remoteForeground": "#e7e7e7",
-        "titleBar.activeBackground": "#0000ff",
-        "titleBar.activeForeground": "#e7e7e7",
-        "titleBar.inactiveBackground": "#0000ff99",
-        "titleBar.inactiveForeground": "#e7e7e799"
-    },
-    "peacock.remoteColor": "blue"
+    "python.testing.pytestEnabled": true
 }

--- a/network/mclag.py
+++ b/network/mclag.py
@@ -2,7 +2,6 @@
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
 from rest_framework import status
-import traceback
 
 from orca_nw_lib.common import MclagFastConvergence
 from orca_nw_lib.mclag import (
@@ -141,7 +140,6 @@ def device_mclag_list(request):
                     add_msg_to_list(result, get_success_msg(request))
                 except Exception as err:
                     add_msg_to_list(result, get_failure_msg(err, request))
-                    print(traceback.format_exc())
                     http_status = http_status and False
 
             for mem in mclag_members:

--- a/network/mclag.py
+++ b/network/mclag.py
@@ -2,6 +2,7 @@
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
 from rest_framework import status
+import traceback
 
 from orca_nw_lib.common import MclagFastConvergence
 from orca_nw_lib.mclag import (
@@ -110,6 +111,9 @@ def device_mclag_list(request):
             mclag_members = req_data.get("mclag_members", [])
             fast_convergence = req_data.get("fast_convergence", None)
             session_vrf = req_data.get("session_vrf", None)
+            keepalive_interval = req_data.get("keepalive_interval", 1)
+            session_timeout = req_data.get("session_timeout", 30)
+            delay_restore = req_data.get("delay_restore", 300)
 
             if not device_ip or not domain_id:
                 return Response(
@@ -119,7 +123,7 @@ def device_mclag_list(request):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
-            if src_addr and peer_addr and peer_link and mclag_sys_mac:
+            if domain_id:
                 try:
                     config_mclag(
                         device_ip=device_ip,
@@ -129,11 +133,15 @@ def device_mclag_list(request):
                         peer_link=peer_link,
                         mclag_sys_mac=mclag_sys_mac,
                         fast_convergence=MclagFastConvergence.get_enum_from_str(fast_convergence),
-                        session_vrf=session_vrf
+                        session_vrf=session_vrf,
+                        keepalive_int = keepalive_interval,
+                        session_timeout = session_timeout,
+                        delay_restore = delay_restore,
                     )
                     add_msg_to_list(result, get_success_msg(request))
                 except Exception as err:
                     add_msg_to_list(result, get_failure_msg(err, request))
+                    print(traceback.format_exc())
                     http_status = http_status and False
 
             for mem in mclag_members:
@@ -143,6 +151,7 @@ def device_mclag_list(request):
                 except Exception as err:
                     add_msg_to_list(result, get_failure_msg(err, request))
                     http_status = http_status and False
+                    print(traceback.format_exc())
 
     return Response(
         {"result": result},

--- a/network/mclag.py
+++ b/network/mclag.py
@@ -151,7 +151,6 @@ def device_mclag_list(request):
                 except Exception as err:
                     add_msg_to_list(result, get_failure_msg(err, request))
                     http_status = http_status and False
-                    print(traceback.format_exc())
 
     return Response(
         {"result": result},

--- a/network/mclag.py
+++ b/network/mclag.py
@@ -1,4 +1,5 @@
 """ MCLAG API """
+
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
 from rest_framework import status
@@ -15,7 +16,7 @@ from orca_nw_lib.mclag import (
     config_mclag_mem_portchnl,
     del_mclag_member,
     remove_mclag_domain_fast_convergence,
-    add_mclag_domain_fast_convergence
+    add_mclag_domain_fast_convergence,
 )
 
 from log_manager.decorators import log_request
@@ -63,9 +64,7 @@ def device_mclag_list(request):
         for req_data in (
             request.data
             if isinstance(request.data, list)
-            else [request.data]
-            if request.data
-            else []
+            else [request.data] if request.data else []
         ):
             device_ip = req_data.get("mgt_ip", "")
             mclag_members = req_data.get("mclag_members", None)
@@ -97,9 +96,7 @@ def device_mclag_list(request):
         for req_data in (
             request.data
             if isinstance(request.data, list)
-            else [request.data]
-            if request.data
-            else []
+            else [request.data] if request.data else []
         ):
             device_ip = req_data.get("mgt_ip", "")
             domain_id = req_data.get("domain_id", "")
@@ -131,11 +128,13 @@ def device_mclag_list(request):
                         peer_addr=peer_addr,
                         peer_link=peer_link,
                         mclag_sys_mac=mclag_sys_mac,
-                        fast_convergence=MclagFastConvergence.get_enum_from_str(fast_convergence),
+                        fast_convergence=MclagFastConvergence.get_enum_from_str(
+                            fast_convergence
+                        ),
                         session_vrf=session_vrf,
-                        keepalive_int = keepalive_interval,
-                        session_timeout = session_timeout,
-                        delay_restore = delay_restore,
+                        keepalive_int=keepalive_interval,
+                        session_timeout=session_timeout,
+                        delay_restore=delay_restore,
                     )
                     add_msg_to_list(result, get_success_msg(request))
                 except Exception as err:
@@ -152,9 +151,9 @@ def device_mclag_list(request):
 
     return Response(
         {"result": result},
-        status=status.HTTP_200_OK
-        if http_status
-        else status.HTTP_500_INTERNAL_SERVER_ERROR,
+        status=(
+            status.HTTP_200_OK if http_status else status.HTTP_500_INTERNAL_SERVER_ERROR
+        ),
     )
 
 
@@ -251,13 +250,13 @@ def config_mclag_fast_convergence(request):
         for req_data in (
             request.data
             if isinstance(request.data, list)
-            else [request.data]
-            if request.data
-            else []
+            else [request.data] if request.data else []
         ):
             device_ip = req_data.get("mgt_ip", None)
             domain_id = req_data.get("domain_id", None)
-            fast_convergence = MclagFastConvergence.get_enum_from_str(req_data.get("fast_convergence", None))
+            fast_convergence = MclagFastConvergence.get_enum_from_str(
+                req_data.get("fast_convergence", None)
+            )
             if not device_ip or not domain_id:
                 return Response(
                     {
@@ -278,7 +277,7 @@ def config_mclag_fast_convergence(request):
                 http_status = http_status and False
     return Response(
         {"result": result},
-        status=status.HTTP_200_OK
-        if http_status
-        else status.HTTP_500_INTERNAL_SERVER_ERROR,
+        status=(
+            status.HTTP_200_OK if http_status else status.HTTP_500_INTERNAL_SERVER_ERROR
+        ),
     )

--- a/network/test/test_mclag.py
+++ b/network/test/test_mclag.py
@@ -203,44 +203,6 @@ class TestMclag(TestORCA):
 
         self.remove_mclag(device_ip_1)
 
-    def test_mclag_fast_convergance(self):
-        device_ip_1 = self.device_ips[0]
-
-        # create mclag with only domain id and fast_convergence
-        request_body = {
-            "mgt_ip": device_ip_1,
-            "domain_id": self.domain_id,
-            "fast_convergence": "enable",
-        }
-
-        response = self.put_req("device_mclag_list", request_body)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        response = self.get_req(
-            "device_mclag_list", {"mgt_ip": device_ip_1, "domain_id": self.domain_id}
-        )
-
-        self.assertEqual(response.json().get("domain_id"), self.domain_id)
-        self.assertEqual(response.json().get("fast_convergence"), request_body['fast_convergence'])
-
-        # update fast_convergence
-        request_body = {
-            "mgt_ip": device_ip_1,
-            "domain_id": self.domain_id,
-            "fast_convergence": "disable",
-        }
-
-        response = self.put_req("device_mclag_list", request_body)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        response = self.get_req(
-            "device_mclag_list", {"mgt_ip": device_ip_1, "domain_id": self.domain_id}
-        )
-
-        self.assertEqual(response.json().get("domain_id"), self.domain_id)
-        self.assertEqual(response.json().get("fast_convergence"), None)
-
-        self.remove_mclag(device_ip_1)
 
     def test_mclag_member_config(self):
         """

--- a/network/test/test_mclag.py
+++ b/network/test/test_mclag.py
@@ -42,24 +42,6 @@ class TestMclag(TestORCA):
         response = self.get_req("device_mclag_list", {"mgt_ip": device_ip_1})
         self.assertTrue(response.status_code == status.HTTP_204_NO_CONTENT)
         self.assertFalse(response.data)
-        
-        # create mclag with only domain id and session_timeout
-        
-        request_body = {
-            "mgt_ip": device_ip_1,
-            "domain_id": self.domain_id,
-            "session_timeout": 30,
-        }
-        
-        response = self.put_req("device_mclag_list", request_body)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        response = self.get_req(
-            "device_mclag_list", {"mgt_ip": device_ip_1, "domain_id": self.domain_id}
-        )
-
-        self.assertEqual(response.json().get("domain_id"), self.domain_id)
-        self.remove_mclag(device_ip_1)
 
         # Create peerlink port channel first
         req = {
@@ -91,6 +73,173 @@ class TestMclag(TestORCA):
         self.assertEqual(response.json().get("peer_link"), self.peer_link)
         self.assertEqual(response.json().get("mclag_sys_mac"), self.mclag_sys_mac)
         # Finally remove mclag
+        self.remove_mclag(device_ip_1)
+
+    def test_mclag_delay_restore(self):
+        device_ip_1 = self.device_ips[0]
+
+        # create mclag with only domain id and delay_restore
+        request_body = {
+            "mgt_ip": device_ip_1,
+            "domain_id": self.domain_id,
+            "delay_restore": 300,
+        }
+
+        response = self.put_req("device_mclag_list", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response = self.get_req(
+            "device_mclag_list", {"mgt_ip": device_ip_1, "domain_id": self.domain_id}
+        )
+
+        self.assertEqual(response.json().get("domain_id"), self.domain_id)
+        self.assertEqual(
+            response.json().get("delay_restore"), request_body["delay_restore"]
+        )
+
+        # update delay_restore
+        request_body = {
+            "mgt_ip": device_ip_1,
+            "domain_id": self.domain_id,
+            "delay_restore": 400,
+        }
+
+        response = self.put_req("device_mclag_list", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response = self.get_req(
+            "device_mclag_list", {"mgt_ip": device_ip_1, "domain_id": self.domain_id}
+        )
+
+        self.assertEqual(response.json().get("domain_id"), self.domain_id)
+        self.assertEqual(
+            response.json().get("delay_restore"), request_body["delay_restore"]
+        )
+
+        self.remove_mclag(device_ip_1)
+
+    def test_mclag_session_timeout(self):
+        device_ip_1 = self.device_ips[0]
+        # create mclag with only domain id and session_timeout
+        request_body = {
+            "mgt_ip": device_ip_1,
+            "domain_id": self.domain_id,
+            "session_timeout": 30,
+        }
+
+        response = self.put_req("device_mclag_list", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response = self.get_req(
+            "device_mclag_list", {"mgt_ip": device_ip_1, "domain_id": self.domain_id}
+        )
+
+        self.assertEqual(response.json().get("domain_id"), self.domain_id)
+        self.assertEqual(
+            response.json().get("session_timeout"), request_body["session_timeout"]
+        )
+
+        # update session timeout
+        request_body = {
+            "mgt_ip": device_ip_1,
+            "domain_id": self.domain_id,
+            "session_timeout": 60,
+        }
+
+        response = self.put_req("device_mclag_list", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response = self.get_req(
+            "device_mclag_list", {"mgt_ip": device_ip_1, "domain_id": self.domain_id}
+        )
+
+        self.assertEqual(response.json().get("domain_id"), self.domain_id)
+        self.assertEqual(
+            response.json().get("session_timeout"), request_body["session_timeout"]
+        )
+        self.remove_mclag(device_ip_1)
+
+    def test_mclag_keepalive_interval(self):
+        device_ip_1 = self.device_ips[0]
+        # create mclag with only domain id and keepalive_interval
+        request_body = {
+            "mgt_ip": device_ip_1,
+            "domain_id": self.domain_id,
+            "keepalive_interval": 1,
+        }
+
+        response = self.put_req("device_mclag_list", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response = self.get_req(
+            "device_mclag_list", {"mgt_ip": device_ip_1, "domain_id": self.domain_id}
+        )
+
+        self.assertEqual(response.json().get("domain_id"), self.domain_id)
+        self.assertEqual(
+            response.json().get("keepalive_interval"),
+            request_body["keepalive_interval"],
+        )
+
+        # update keepalive_interval
+        request_body = {
+            "mgt_ip": device_ip_1,
+            "domain_id": self.domain_id,
+            "keepalive_interval": 1,
+        }
+
+        response = self.put_req("device_mclag_list", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response = self.get_req(
+            "device_mclag_list", {"mgt_ip": device_ip_1, "domain_id": self.domain_id}
+        )
+
+        self.assertEqual(response.json().get("domain_id"), self.domain_id)
+        self.assertEqual(
+            response.json().get("keepalive_interval"),
+            request_body["keepalive_interval"],
+        )
+
+        self.remove_mclag(device_ip_1)
+
+    def test_mclag_fast_convergance(self):
+        device_ip_1 = self.device_ips[0]
+
+        # create mclag with only domain id and fast_convergence
+        request_body = {
+            "mgt_ip": device_ip_1,
+            "domain_id": self.domain_id,
+            "fast_convergence": "enable",
+        }
+
+        response = self.put_req("device_mclag_list", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response = self.get_req(
+            "device_mclag_list", {"mgt_ip": device_ip_1, "domain_id": self.domain_id}
+        )
+
+        self.assertEqual(response.json().get("domain_id"), self.domain_id)
+        self.assertEqual(response.json().get("fast_convergence"), request_body['fast_convergence'])
+
+        # update fast_convergence
+        request_body = {
+            "mgt_ip": device_ip_1,
+            "domain_id": self.domain_id,
+            "fast_convergence": "disable",
+        }
+
+        response = self.put_req("device_mclag_list", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response = self.get_req(
+            "device_mclag_list", {"mgt_ip": device_ip_1, "domain_id": self.domain_id}
+        )
+
+        self.assertEqual(response.json().get("domain_id"), self.domain_id)
+        self.assertEqual(response.json().get("fast_convergence"), None)
+
         self.remove_mclag(device_ip_1)
 
     def test_mclag_member_config(self):
@@ -194,6 +343,7 @@ class TestMclag(TestORCA):
 
         # cleanup members
         response = self.del_req("device_mclag_list", request_body_members)
+        print('---', response)
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(

--- a/network/test/test_mclag.py
+++ b/network/test/test_mclag.py
@@ -35,7 +35,8 @@ class TestMclag(TestORCA):
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(
-                "resource not found" in res.get("message", "").lower() for res in response.json()["result"]
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
                 if res != "\n"
             )
         )
@@ -203,7 +204,6 @@ class TestMclag(TestORCA):
 
         self.remove_mclag(device_ip_1)
 
-
     def test_mclag_member_config(self):
         """
         Test the MCLAG member configuration.
@@ -223,7 +223,8 @@ class TestMclag(TestORCA):
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(
-                "resource not found" in res.get("message", "").lower() for res in response.json()["result"]
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
                 if res != "\n"
             )
         )
@@ -289,7 +290,8 @@ class TestMclag(TestORCA):
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(
-                "resource not found" in res.get("message", "").lower() for res in response.json()["result"]
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
                 if res != "\n"
             )
         )
@@ -305,11 +307,12 @@ class TestMclag(TestORCA):
 
         # cleanup members
         response = self.del_req("device_mclag_list", request_body_members)
-        print('---', response)
+        print("---", response)
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(
-                "resource not found" in res.get("message", "").lower() for res in response.json()["result"]
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
                 if res != "\n"
             )
         )
@@ -318,7 +321,8 @@ class TestMclag(TestORCA):
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(
-                "resource not found" in res.get("message", "").lower() for res in response.json()["result"]
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
                 if res != "\n"
             )
         )
@@ -341,7 +345,8 @@ class TestMclag(TestORCA):
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(
-                "resource not found" in res.get("message", "").lower() for res in response.json()["result"]
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
                 if res != "\n"
             )
         )
@@ -368,7 +373,8 @@ class TestMclag(TestORCA):
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(
-                "resource not found" in res.get("message", "").lower() for res in response.json()["result"]
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
                 if res != "\n"
             )
         )
@@ -387,7 +393,8 @@ class TestMclag(TestORCA):
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(
-                "resource not found" in res.get("message", "").lower() for res in response.json()["result"]
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
                 if res != "\n"
             )
         )
@@ -411,7 +418,7 @@ class TestMclag(TestORCA):
             "peer_addr": device_ip_2,
             "peer_link": self.peer_link,
             "mclag_sys_mac": self.mclag_sys_mac,
-            "fast_convergence": "enable"
+            "fast_convergence": "enable",
         }
 
         response = self.put_req("device_mclag_list", request_body)
@@ -437,7 +444,7 @@ class TestMclag(TestORCA):
             "peer_addr": device_ip_2,
             "peer_link": self.peer_link,
             "mclag_sys_mac": self.mclag_sys_mac,
-            "fast_convergence": "disable"
+            "fast_convergence": "disable",
         }
 
         response = self.put_req("device_mclag_list", request_body)
@@ -465,7 +472,8 @@ class TestMclag(TestORCA):
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(
-                "resource not found" in res.get("message", "").lower() for res in response.json()["result"]
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
                 if res != "\n"
             )
         )
@@ -488,7 +496,7 @@ class TestMclag(TestORCA):
             "source_address": device_ip_1,
             "peer_addr": device_ip_2,
             "peer_link": self.peer_link,
-            "mclag_sys_mac": self.mclag_sys_mac
+            "mclag_sys_mac": self.mclag_sys_mac,
         }
 
         response = self.put_req("device_mclag_list", request_body)
@@ -511,8 +519,8 @@ class TestMclag(TestORCA):
             req_json={
                 "mgt_ip": device_ip_1,
                 "domain_id": self.domain_id,
-                "fast_convergence": "enable"
-            }
+                "fast_convergence": "enable",
+            },
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -529,8 +537,8 @@ class TestMclag(TestORCA):
             req_json={
                 "mgt_ip": device_ip_1,
                 "domain_id": self.domain_id,
-                "fast_convergence": "disable"
-            }
+                "fast_convergence": "disable",
+            },
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/network/test/test_mclag.py
+++ b/network/test/test_mclag.py
@@ -42,6 +42,24 @@ class TestMclag(TestORCA):
         response = self.get_req("device_mclag_list", {"mgt_ip": device_ip_1})
         self.assertTrue(response.status_code == status.HTTP_204_NO_CONTENT)
         self.assertFalse(response.data)
+        
+        # create mclag with only domain id and session_timeout
+        
+        request_body = {
+            "mgt_ip": device_ip_1,
+            "domain_id": self.domain_id,
+            "session_timeout": 30,
+        }
+        
+        response = self.put_req("device_mclag_list", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response = self.get_req(
+            "device_mclag_list", {"mgt_ip": device_ip_1, "domain_id": self.domain_id}
+        )
+
+        self.assertEqual(response.json().get("domain_id"), self.domain_id)
+        self.remove_mclag(device_ip_1)
 
         # Create peerlink port channel first
         req = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ djangorestframework = "^3.14.0"
 django-cors-headers = "^3.14.0"
 pytest = "^7.3.2"
 pytest-django = "^4.7.0"
-orca-nw-lib = "^1.3.18"
+orca-nw-lib = "^1.3.19"
 packaging = "^23.2"# Because of langchain dependencies in ORCASK, packaging should not be greater than 23.y.z.
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ djangorestframework = "^3.14.0"
 django-cors-headers = "^3.14.0"
 pytest = "^7.3.2"
 pytest-django = "^4.7.0"
-orca-nw-lib = "^1.3.15"
+orca-nw-lib = "^1.3.18"
 packaging = "^23.2"# Because of langchain dependencies in ORCASK, packaging should not be greater than 23.y.z.
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ djangorestframework = "^3.14.0"
 django-cors-headers = "^3.14.0"
 pytest = "^7.3.2"
 pytest-django = "^4.7.0"
-orca-nw-lib = "^1.3.17"
+orca-nw-lib = "^1.3.18"
 packaging = "^23.2"# Because of langchain dependencies in ORCASK, packaging should not be greater than 23.y.z.
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
related [#63](https://github.com/STORDIS/orca_nw_lib/issues/63)

added functionality to take configuration like 
- session_vrf
- keepalive_int
- session_timeout
- delay_restore

added functionality where only domain id and any other felid can be passed to trigger mclag addition
added default values
added test case to check mclag creation only with domain id and one other param