### PR TITLE
Configure mclag ports - b - #65

### DIFF
--- a/network/mclag.py
+++ b/network/mclag.py
@@ -80,9 +80,13 @@ def device_mclag_list(request):
             # If member are given in the request body
             # Delete the members only, otherwise request is considered
             # to be for deleting the MCLAG
-            if mclag_members:
+            if "mclag_members" in req_data:
                 try:
-                    del_mclag_member(device_ip)
+                    if len(mclag_members):
+                        for mem in mclag_members:
+                            del_mclag_member(device_ip, mem)
+                    else:
+                        del_mclag_member(device_ip)
                     add_msg_to_list(result, get_success_msg(request))
                 except Exception as err:
                     add_msg_to_list(result, get_failure_msg(err, request))

--- a/network/mclag.py
+++ b/network/mclag.py
@@ -53,9 +53,11 @@ def device_mclag_list(request):
             )
         domain_id = request.GET.get("domain_id", None)
         data = get_mclags(device_ip, domain_id)
+        
         if data:
             for i in data if isinstance(data, list) else [data]:
                 i["mclag_members"] = [mem["lag_name"] for mem in get_mclag_mem_portchnls(device_ip, i["domain_id"])]
+                i['gateway_mac'] = get_mclag_gw_mac(device_ip)[0].get('gateway_mac')
         return (
             Response(data, status=status.HTTP_200_OK)
             if data

--- a/network/mclag.py
+++ b/network/mclag.py
@@ -83,13 +83,10 @@ def device_mclag_list(request):
             # If member are given in the request body
             # Delete the members only, otherwise request is considered
             # to be for deleting the MCLAG
-            if "mclag_members" in req_data:
+            if mclag_members:
                 try:
-                    if len(mclag_members):
-                        for mem in mclag_members:
-                            del_mclag_member(device_ip, mem)
-                    else:
-                        del_mclag_member(device_ip)
+                    for mem in mclag_members or []:
+                        del_mclag_member(device_ip, mem)
                     add_msg_to_list(result, get_success_msg(request))
                 except Exception as err:
                     add_msg_to_list(result, get_failure_msg(err, request))

--- a/network/mclag.py
+++ b/network/mclag.py
@@ -54,10 +54,13 @@ def device_mclag_list(request):
         domain_id = request.GET.get("domain_id", None)
         data = get_mclags(device_ip, domain_id)
         
+        mclag_gateway_mac_details = get_mclag_gw_mac(device_ip)
+        
         if data:
             for i in data if isinstance(data, list) else [data]:
                 i["mclag_members"] = [mem["lag_name"] for mem in get_mclag_mem_portchnls(device_ip, i["domain_id"])]
-                i['gateway_mac'] = get_mclag_gw_mac(device_ip)[0].get('gateway_mac')
+                if len(mclag_gateway_mac_details):
+                    i['gateway_mac'] = mclag_gateway_mac_details[0].get('gateway_mac')
         return (
             Response(data, status=status.HTTP_200_OK)
             if data

--- a/network/test/test_mclag.py
+++ b/network/test/test_mclag.py
@@ -359,6 +359,8 @@ class TestMclag(TestORCA):
 
         response = self.get_req("device_mclag_list", request_body_delete_members)
         self.assertEqual(response.json().get("domain_id"), request_body_delete_members['domain_id'])
+        self.assertEqual(len(response.json().get("mclag_members")), 0)
+
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(
@@ -464,7 +466,6 @@ class TestMclag(TestORCA):
             "peer_link": self.peer_link,
             "mclag_sys_mac": self.mclag_sys_mac,
             "fast_convergence": "enable",
-            "fast_convergence": "enable",
         }
 
         response = self.put_req("device_mclag_list", request_body)
@@ -490,7 +491,6 @@ class TestMclag(TestORCA):
             "peer_addr": device_ip_2,
             "peer_link": self.peer_link,
             "mclag_sys_mac": self.mclag_sys_mac,
-            "fast_convergence": "disable",
             "fast_convergence": "disable",
         }
 
@@ -543,7 +543,6 @@ class TestMclag(TestORCA):
             "source_address": device_ip_1,
             "peer_addr": device_ip_2,
             "peer_link": self.peer_link,
-            "mclag_sys_mac": self.mclag_sys_mac,
             "mclag_sys_mac": self.mclag_sys_mac,
         }
 

--- a/network/test/test_mclag.py
+++ b/network/test/test_mclag.py
@@ -37,8 +37,6 @@ class TestMclag(TestORCA):
             or any(
                 "resource not found" in res.get("message", "").lower()
                 for res in response.json()["result"]
-                "resource not found" in res.get("message", "").lower()
-                for res in response.json()["result"]
                 if res != "\n"
             )
         )
@@ -370,8 +368,6 @@ class TestMclag(TestORCA):
             or any(
                 "resource not found" in res.get("message", "").lower()
                 for res in response.json()["result"]
-                "resource not found" in res.get("message", "").lower()
-                for res in response.json()["result"]
                 if res != "\n"
             )
         )
@@ -391,8 +387,6 @@ class TestMclag(TestORCA):
             or any(
                 "resource not found" in res.get("message", "").lower()
                 for res in response.json()["result"]
-                "resource not found" in res.get("message", "").lower()
-                for res in response.json()["result"]
                 if res != "\n"
             )
         )
@@ -401,8 +395,6 @@ class TestMclag(TestORCA):
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(
-                "resource not found" in res.get("message", "").lower()
-                for res in response.json()["result"]
                 "resource not found" in res.get("message", "").lower()
                 for res in response.json()["result"]
                 if res != "\n"
@@ -427,8 +419,6 @@ class TestMclag(TestORCA):
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(
-                "resource not found" in res.get("message", "").lower()
-                for res in response.json()["result"]
                 "resource not found" in res.get("message", "").lower()
                 for res in response.json()["result"]
                 if res != "\n"
@@ -459,8 +449,6 @@ class TestMclag(TestORCA):
             or any(
                 "resource not found" in res.get("message", "").lower()
                 for res in response.json()["result"]
-                "resource not found" in res.get("message", "").lower()
-                for res in response.json()["result"]
                 if res != "\n"
             )
         )
@@ -479,8 +467,6 @@ class TestMclag(TestORCA):
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(
-                "resource not found" in res.get("message", "").lower()
-                for res in response.json()["result"]
                 "resource not found" in res.get("message", "").lower()
                 for res in response.json()["result"]
                 if res != "\n"
@@ -564,8 +550,6 @@ class TestMclag(TestORCA):
             or any(
                 "resource not found" in res.get("message", "").lower()
                 for res in response.json()["result"]
-                "resource not found" in res.get("message", "").lower()
-                for res in response.json()["result"]
                 if res != "\n"
             )
         )
@@ -614,8 +598,6 @@ class TestMclag(TestORCA):
                 "domain_id": self.domain_id,
                 "fast_convergence": "enable",
             },
-                "fast_convergence": "enable",
-            },
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -632,8 +614,6 @@ class TestMclag(TestORCA):
             req_json={
                 "mgt_ip": device_ip_1,
                 "domain_id": self.domain_id,
-                "fast_convergence": "disable",
-            },
                 "fast_convergence": "disable",
             },
         )

--- a/network/test/test_mclag.py
+++ b/network/test/test_mclag.py
@@ -35,22 +35,23 @@ class TestMclag(TestORCA):
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(
-                "resource not found" in res.get("message", "").lower() for res in response.json()["result"]
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
                 if res != "\n"
             )
         )
         response = self.get_req("device_mclag_list", {"mgt_ip": device_ip_1})
         self.assertTrue(response.status_code == status.HTTP_204_NO_CONTENT)
         self.assertFalse(response.data)
-        
+
         # create mclag with only domain id and session_timeout
-        
+
         request_body = {
             "mgt_ip": device_ip_1,
             "domain_id": self.domain_id,
             "session_timeout": 30,
         }
-        
+
         response = self.put_req("device_mclag_list", request_body)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -112,7 +113,8 @@ class TestMclag(TestORCA):
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(
-                "resource not found" in res.get("message", "").lower() for res in response.json()["result"]
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
                 if res != "\n"
             )
         )
@@ -168,6 +170,7 @@ class TestMclag(TestORCA):
         self.perform_del_port_chnl(request_body)
         self.perform_add_port_chnl(request_body)
 
+        # create mclag and add member
         request_body_members = {
             "mgt_ip": device_ip_1,
             "domain_id": self.domain_id,
@@ -178,7 +181,65 @@ class TestMclag(TestORCA):
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(
-                "resource not found" in res.get("message", "").lower() for res in response.json()["result"]
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
+                if res != "\n"
+            )
+        )
+        response = self.put_req("device_mclag_list", request_body_members)
+
+        # check deletion of single member
+        request_body_member = {
+            "mgt_ip": device_ip_1,
+            "domain_id": self.domain_id,
+            "mclag_members": [self.mem_port_chnl],
+        }
+
+        response = self.del_req("device_mclag_list", request_body_member)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        response = self.get_req("device_mclag_list", request_body_members)
+        self.assertEqual(response.json().get("mclag_members")[0], self.mem_port_chnl_2)
+
+        # check deletion of all members with empty member array
+        request_body_member = {
+            "mgt_ip": device_ip_1,
+            "domain_id": self.domain_id,
+            "mclag_members": [],
+        }
+        response = self.del_req("device_mclag_list", request_body_member)
+        self.assertTrue(
+            response.status_code == status.HTTP_200_OK
+            or any(
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
+                if res != "\n"
+            )
+        )
+
+        # cleanup mclag
+        response = self.del_req("device_mclag_list", request_body)
+        self.assertTrue(
+            response.status_code == status.HTTP_200_OK
+            or any(
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
+                if res != "\n"
+            )
+        )
+
+        request_body_members = {
+            "mgt_ip": device_ip_1,
+            "domain_id": self.domain_id,
+            "mclag_members": [self.mem_port_chnl, self.mem_port_chnl_2],
+        }
+
+        response = self.del_req("device_mclag_list", request_body_members)
+        self.assertTrue(
+            response.status_code == status.HTTP_200_OK
+            or any(
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
                 if res != "\n"
             )
         )
@@ -188,16 +249,15 @@ class TestMclag(TestORCA):
         self.assertTrue(response.status_code == status.HTTP_200_OK)
         self.assertEqual(len(response.json().get("mclag_members")), 2)
         for mem in response.json().get("mclag_members"):
-            self.assertTrue(
-                mem in [self.mem_port_chnl, self.mem_port_chnl_2]
-            )
+            self.assertTrue(mem in [self.mem_port_chnl, self.mem_port_chnl_2])
 
         # cleanup members
         response = self.del_req("device_mclag_list", request_body_members)
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(
-                "resource not found" in res.get("message", "").lower() for res in response.json()["result"]
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
                 if res != "\n"
             )
         )
@@ -206,7 +266,8 @@ class TestMclag(TestORCA):
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(
-                "resource not found" in res.get("message", "").lower() for res in response.json()["result"]
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
                 if res != "\n"
             )
         )
@@ -229,7 +290,8 @@ class TestMclag(TestORCA):
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(
-                "resource not found" in res.get("message", "").lower() for res in response.json()["result"]
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
                 if res != "\n"
             )
         )
@@ -256,7 +318,8 @@ class TestMclag(TestORCA):
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(
-                "resource not found" in res.get("message", "").lower() for res in response.json()["result"]
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
                 if res != "\n"
             )
         )
@@ -275,7 +338,8 @@ class TestMclag(TestORCA):
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(
-                "resource not found" in res.get("message", "").lower() for res in response.json()["result"]
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
                 if res != "\n"
             )
         )
@@ -299,7 +363,7 @@ class TestMclag(TestORCA):
             "peer_addr": device_ip_2,
             "peer_link": self.peer_link,
             "mclag_sys_mac": self.mclag_sys_mac,
-            "fast_convergence": "enable"
+            "fast_convergence": "enable",
         }
 
         response = self.put_req("device_mclag_list", request_body)
@@ -325,7 +389,7 @@ class TestMclag(TestORCA):
             "peer_addr": device_ip_2,
             "peer_link": self.peer_link,
             "mclag_sys_mac": self.mclag_sys_mac,
-            "fast_convergence": "disable"
+            "fast_convergence": "disable",
         }
 
         response = self.put_req("device_mclag_list", request_body)
@@ -353,7 +417,8 @@ class TestMclag(TestORCA):
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(
-                "resource not found" in res.get("message", "").lower() for res in response.json()["result"]
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
                 if res != "\n"
             )
         )
@@ -376,7 +441,7 @@ class TestMclag(TestORCA):
             "source_address": device_ip_1,
             "peer_addr": device_ip_2,
             "peer_link": self.peer_link,
-            "mclag_sys_mac": self.mclag_sys_mac
+            "mclag_sys_mac": self.mclag_sys_mac,
         }
 
         response = self.put_req("device_mclag_list", request_body)
@@ -399,8 +464,8 @@ class TestMclag(TestORCA):
             req_json={
                 "mgt_ip": device_ip_1,
                 "domain_id": self.domain_id,
-                "fast_convergence": "enable"
-            }
+                "fast_convergence": "enable",
+            },
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -417,8 +482,8 @@ class TestMclag(TestORCA):
             req_json={
                 "mgt_ip": device_ip_1,
                 "domain_id": self.domain_id,
-                "fast_convergence": "disable"
-            }
+                "fast_convergence": "disable",
+            },
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -448,7 +513,8 @@ class TestMclag(TestORCA):
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(
-                "resource not found" in res.get("message", "").lower() for res in response.json()["result"]
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
                 if res != "\n"
             )
         )
@@ -462,7 +528,8 @@ class TestMclag(TestORCA):
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(
-                "resource not found" in res.get("message", "").lower() for res in response.json()["result"]
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
                 if res != "\n"
             )
         )
@@ -487,7 +554,7 @@ class TestMclag(TestORCA):
             "peer_addr": device_ip_2,
             "peer_link": self.peer_link,
             "mclag_sys_mac": self.mclag_sys_mac,
-            "gateway_mac": gw_mac
+            "gateway_mac": gw_mac,
         }
 
         response = self.put_req("device_mclag_list", request_body)
@@ -514,7 +581,8 @@ class TestMclag(TestORCA):
         self.assertTrue(
             response.status_code == status.HTTP_200_OK
             or any(
-                "resource not found" in res.get("message", "").lower() for res in response.json()["result"]
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
                 if res != "\n"
             )
         )

--- a/network/urls.py
+++ b/network/urls.py
@@ -18,6 +18,7 @@ urlpatterns = [
     path("port_chnl_ip_remove", port_chnl.remove_port_channel_ip_address, name="port_channel_ip_remove"),
     path("port_chnl_vlan_member_remove", port_chnl.remove_port_channel_member_vlan, name="port_chnl_vlan_member_remove"),
     re_path("mclags", mclag.device_mclag_list, name="device_mclag_list"),
+    path("delete_mclag_members", mclag.delete_mclag_members, name="delete_mclag_members"),
     re_path("config_mclag_fast_convergence", mclag.config_mclag_fast_convergence, name="config_mclag_fast_convergence"),
     re_path("bgp", bgp.device_bgp_global, name="bgp_global"),
     re_path("nbrs", bgp.bgp_nbr_config, name="bgp_nbr"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ djangorestframework = "^3.14.0"
 django-cors-headers = "^3.14.0"
 pytest = "^7.3.2"
 pytest-django = "^4.7.0"
-orca-nw-lib = "^1.3.18"
+orca-nw-lib = "^1.3.20"
 packaging = "^23.2"# Because of langchain dependencies in ORCASK, packaging should not be greater than 23.y.z.
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
backend fix for [#65](https://github.com/STORDIS/orca_nw_lib/issues/65)

Functionality which will suport the deletion of single member (Portchannel) of mclag
if the member are provided it will delete only those portchannels else it will delete all the portchannels form members.
Respective test cases are added to check the deletion of a single member and also delete all the members.

There is if statement in the mclag.py which will check 

- if members is provided as key and with portchannel names as values it will remove only those portchannels.
- if member keys is provided with empty array it will remove all the members 
- if there is no member key then it will delete the mclag 