### PR TITLE
STP Configuration in ORCA (New Tab) #57

### DIFF
--- a/network/stp.py
+++ b/network/stp.py
@@ -1,0 +1,175 @@
+import traceback
+
+from rest_framework.decorators import api_view
+
+from log_manager.decorators import log_request
+from rest_framework import status
+from rest_framework.response import Response
+
+from network.util import add_msg_to_list, get_success_msg, get_failure_msg
+from orca_nw_lib.common import STPEnabledProtocol
+from orca_nw_lib.stp import (config_stp_global,
+                             get_stp_global_config,
+                             delete_stp_global_config, delete_stp_global_config_disabled_vlans)
+
+
+@api_view(["GET", "PUT", "DELETE"])
+@log_request
+def stp_global_config(request):
+    """
+    Generates the function comment for the given function body.
+
+    Args:
+        request (Request): The request object.
+
+    Returns:
+        Response: The response object containing the result of the function.
+
+    Input put request body details:
+    device_ip (str): The IP address of the device.
+    enabled_protocol (list): List of enabled STP protocols. Valid Values: PVST, MSTP, RSTP, RAPID_PVST.
+    bpdu_filter (bool): Enable/Disable BPDU filter. Valid Values: True, False.
+    bridge_priority (int): The bridge priority value. Valid Range: 0-61440, only multiples of 4096.
+    max_age (int): Maximum age value for STP. Valid Range: 6-40.
+    hello_time (int): Hello time value for STP. Valid Range: 1-10.
+    forwarding_delay (int): Forwarding delay value for STP. Valid Range: 4-30.
+    disabled_vlans (list[int], optional): List of disabled VLANs. Defaults to None.
+    rootguard_timeout (int, optional): Root guard timeout value. Valid Range to 5-600.
+    loop_guard (bool, optional): Enable/Disable loop guard. Valid Values: True, False.
+    portfast (bool, optional): Enable/Disable portfast. Valid Values: True, False.
+    """
+    result = []
+    http_status = True
+    if request.method == "GET":
+        device_ip = request.GET.get("mgt_ip", "")
+        if not device_ip:
+            return Response(
+                {"status": "Required field device mgt_ip not found."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        data = get_stp_global_config(device_ip)
+        return (
+            Response(data, status=status.HTTP_200_OK)
+            if data
+            else Response({}, status=status.HTTP_204_NO_CONTENT)
+        )
+    for req_data in (request.data if isinstance(request.data, list) else [request.data] if request.data else []):
+        if request.method == "PUT":
+            device_ip = req_data.get("mgt_ip", "")
+            if not device_ip:
+                return Response(
+                    {"status": "Required field device mgt_ip not found."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            enabled_protocol = req_data.get("enabled_protocol")
+            if enabled_protocol is None or enabled_protocol == "":
+                return Response(
+                    {"status": "Required field enabled_protocol not found."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            bpdu_filter = req_data.get("bpdu_filter")
+            if bpdu_filter is None or bpdu_filter == "":
+                return Response(
+                    {"status": "Required field bpdu_filter not found."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            forwarding_delay = req_data.get("forwarding_delay")
+            if forwarding_delay is None or forwarding_delay == "":
+                return Response(
+                    {"status": "Required field forwarding_delay not found."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            hello_time = req_data.get("hello_time")
+            if hello_time is None or hello_time == "":
+                return Response(
+                    {"status": "Required field hello_time not found."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            max_age = req_data.get("max_age")
+            if max_age is None or max_age == "":
+                return Response(
+                    {"status": "Required field max_age not found."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            bridge_priority = req_data.get("bridge_priority")
+            if bridge_priority is None or bridge_priority == "":
+                return Response(
+                    {"status": "Required field bridge_priority not found."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            try:
+                config_stp_global(
+                    device_ip=device_ip,
+                    enabled_protocol=[STPEnabledProtocol.get_enum_from_str(i) for i in enabled_protocol],
+                    bpdu_filter=bpdu_filter,
+                    forwarding_delay=forwarding_delay,
+                    hello_time=hello_time,
+                    max_age=max_age,
+                    bridge_priority=bridge_priority,
+                    disabled_vlans=req_data.get("disabled_vlans"),
+                    rootguard_timeout=req_data.get("rootguard_timeout"),
+                    loop_guard=req_data.get("loop_guard"),
+                    portfast=req_data.get("portfast"),
+                )
+                add_msg_to_list(result, get_success_msg(request))
+            except Exception as err:
+                add_msg_to_list(result, get_failure_msg(err, request))
+                http_status = http_status and False
+        if request.method == "DELETE":
+            device_ip = req_data.get("mgt_ip", "")
+            if not device_ip:
+                return Response(
+                    {"status": "Required field device mgt_ip not found."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            try:
+                delete_stp_global_config(device_ip=device_ip)
+                add_msg_to_list(result, get_success_msg(request))
+            except Exception as err:
+                add_msg_to_list(result, get_failure_msg(err, request))
+                http_status = http_status and False
+    return Response(
+        {"result": result},
+        status=(status.HTTP_200_OK if http_status else status.HTTP_500_INTERNAL_SERVER_ERROR),
+    )
+
+
+@api_view(["DELETE"])
+@log_request
+def delete_disabled_vlans(request):
+    """
+    Deletes disabled VLANs based on the provided request data.
+    Parameters:
+    - `request` (Request): The request object containing the data for deleting disabled VLANs.
+    Returns:
+    - `Response`: The response object indicating the result of the deletion operation.
+    """
+    result = []
+    http_status = True
+    if request.method == "DELETE":
+        req_data = request.data
+        device_ip = req_data.get("mgt_ip", "")
+        if not device_ip:
+            return Response(
+                {"status": "Required field device mgt_ip not found."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        disabled_vlans = req_data.get("disabled_vlans")
+        if not disabled_vlans and len(disabled_vlans) == 0:
+            return Response(
+                {"status": "Required field disabled_vlans not found."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            delete_stp_global_config_disabled_vlans(device_ip=device_ip, disabled_vlans=disabled_vlans)
+            add_msg_to_list(result, get_success_msg(request))
+        except Exception as err:
+            print(traceback.format_exc())
+            add_msg_to_list(result, get_failure_msg(err, request))
+            http_status = http_status and False
+    return Response(
+        {"result": result},
+        status=(status.HTTP_200_OK if http_status else status.HTTP_500_INTERNAL_SERVER_ERROR)
+    )

--- a/network/test/test_stp.py
+++ b/network/test/test_stp.py
@@ -1,0 +1,500 @@
+from rest_framework import status
+
+from network.test.test_common import TestORCA
+
+
+class TestSTP(TestORCA):
+    """
+    This module contains tests for the STP API.
+    """
+
+    def test_stp_global_config(self):
+        """
+        Test stp global config on device.
+        """
+        device_ip = self.device_ips[0]
+        request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["PVST"],
+            "bpdu_filter": True,
+            "forwarding_delay": 10,
+            "hello_time": 10,
+            "max_age": 10,
+            "bridge_priority": 4096
+        }
+
+        # delete stp config if it exists
+        response = self.del_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        # get stp config
+        response = self.get_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_204_NO_CONTENT)
+
+        # create stp config
+        response = self.put_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        response = self.get_req("stp_config", request_body)
+        response_body = response.json()
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+        self.assertEqual(request_body["enabled_protocol"], response_body["enabled_protocol"])
+        self.assertEqual(request_body["bpdu_filter"], response_body["bpdu_filter"])
+        self.assertEqual(request_body["hello_time"], response_body["hello_time"])
+        self.assertEqual(request_body["max_age"], response_body["max_age"])
+        self.assertEqual(request_body["forwarding_delay"], response_body["forwarding_delay"])
+        self.assertEqual(request_body["bridge_priority"], response_body["bridge_priority"])
+
+        # testing updated values
+        request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["PVST"],
+            "bpdu_filter": False,
+            "forwarding_delay": 5,
+            "hello_time": 5,
+            "max_age": 20,
+            "bridge_priority": 4096 * 2
+        }
+
+        # update stp config
+        response = self.put_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        response = self.get_req("stp_config", request_body)
+        response_body = response.json()
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+        self.assertEqual(request_body["enabled_protocol"], response_body["enabled_protocol"])
+        self.assertEqual(request_body["bpdu_filter"], response_body["bpdu_filter"])
+        self.assertEqual(request_body["hello_time"], response_body["hello_time"])
+        self.assertEqual(request_body["max_age"], response_body["max_age"])
+        self.assertEqual(request_body["forwarding_delay"], response_body["forwarding_delay"])
+        self.assertEqual(request_body["bridge_priority"], response_body["bridge_priority"])
+
+        # delete stp config
+        response = self.del_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        # get stp config
+        response = self.get_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_204_NO_CONTENT)
+
+    def test_stp_global_additional_parm_rootguard_timeout_test(self):
+        device_ip = self.device_ips[0]
+        request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["PVST"],
+            "bpdu_filter": True,
+            "forwarding_delay": 10,
+            "hello_time": 10,
+            "max_age": 10,
+            "bridge_priority": 4096,
+            "rootguard_timeout": 10
+        }
+
+        # delete stp config if it exists
+        response = self.del_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        # get stp config
+        response = self.get_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_204_NO_CONTENT)
+
+        # create stp config
+        response = self.put_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        response = self.get_req("stp_config", request_body)
+        response_body = response.json()
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+        self.assertEqual(request_body["rootguard_timeout"], response_body["rootguard_timeout"])
+        self.assertEqual(request_body["enabled_protocol"], response_body["enabled_protocol"])
+        self.assertEqual(request_body["bpdu_filter"], response_body["bpdu_filter"])
+        self.assertEqual(request_body["hello_time"], response_body["hello_time"])
+        self.assertEqual(request_body["max_age"], response_body["max_age"])
+        self.assertEqual(request_body["forwarding_delay"], response_body["forwarding_delay"])
+        self.assertEqual(request_body["bridge_priority"], response_body["bridge_priority"])
+
+        # updating rootguard timeout config
+
+        request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["PVST"],
+            "bpdu_filter": True,
+            "forwarding_delay": 10,
+            "hello_time": 10,
+            "max_age": 10,
+            "bridge_priority": 4096,
+            "rootguard_timeout": 20
+        }
+
+        # update stp config
+        response = self.put_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        response = self.get_req("stp_config", request_body)
+        response_body = response.json()
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+        self.assertEqual(request_body["rootguard_timeout"], response_body["rootguard_timeout"])
+
+        # delete stp config
+        response = self.del_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        # get stp config
+        response = self.get_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_204_NO_CONTENT)
+
+    def test_stp_global_additional_parm_port_fast_test(self):
+        device_ip = self.device_ips[0]
+        request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["PVST"],
+            "bpdu_filter": True,
+            "forwarding_delay": 10,
+            "hello_time": 10,
+            "max_age": 10,
+            "bridge_priority": 4096,
+            "portfast": True
+        }
+
+        # delete stp config if it exists
+        response = self.del_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        # get stp config
+        response = self.get_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_204_NO_CONTENT)
+
+        # create stp config
+        response = self.put_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        response = self.get_req("stp_config", request_body)
+        response_body = response.json()
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+        self.assertEqual(request_body["portfast"], response_body["portfast"])
+        self.assertEqual(request_body["enabled_protocol"], response_body["enabled_protocol"])
+        self.assertEqual(request_body["bpdu_filter"], response_body["bpdu_filter"])
+        self.assertEqual(request_body["hello_time"], response_body["hello_time"])
+        self.assertEqual(request_body["max_age"], response_body["max_age"])
+        self.assertEqual(request_body["forwarding_delay"], response_body["forwarding_delay"])
+        self.assertEqual(request_body["bridge_priority"], response_body["bridge_priority"])
+
+        # updating port fast config
+
+        request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["PVST"],
+            "bpdu_filter": True,
+            "forwarding_delay": 10,
+            "hello_time": 10,
+            "max_age": 10,
+            "bridge_priority": 4096,
+            "portfast": False
+        }
+
+        # update stp config
+        response = self.put_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        response = self.get_req("stp_config", request_body)
+        response_body = response.json()
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+        self.assertEqual(request_body["portfast"], response_body["portfast"])
+
+        # delete stp config
+        response = self.del_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        # get stp config
+        response = self.get_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_204_NO_CONTENT)
+
+    def test_stp_global_additional_parm_loop_guard_test(self):
+        device_ip = self.device_ips[0]
+        request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["MSTP"],
+            "bpdu_filter": True,
+            "forwarding_delay": 10,
+            "hello_time": 10,
+            "max_age": 10,
+            "bridge_priority": 4096,
+            "loop_guard": False
+        }
+
+        # delete stp config if it exists
+        response = self.del_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        # get stp config
+        response = self.get_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_204_NO_CONTENT)
+
+        # create stp config
+        response = self.put_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        response = self.get_req("stp_config", request_body)
+        response_body = response.json()
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+        self.assertEqual(request_body["loop_guard"], response_body["loop_guard"])
+        self.assertEqual(request_body["enabled_protocol"], response_body["enabled_protocol"])
+        self.assertEqual(request_body["bpdu_filter"], response_body["bpdu_filter"])
+        self.assertEqual(request_body["hello_time"], response_body["hello_time"])
+        self.assertEqual(request_body["max_age"], response_body["max_age"])
+        self.assertEqual(request_body["forwarding_delay"], response_body["forwarding_delay"])
+        self.assertEqual(request_body["bridge_priority"], response_body["bridge_priority"])
+
+        # updating loop guard config
+
+        request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["MSTP"],
+            "bpdu_filter": True,
+            "forwarding_delay": 10,
+            "hello_time": 10,
+            "max_age": 10,
+            "bridge_priority": 4096,
+            "loop_guard": False
+        }
+
+        # update stp config
+        response = self.put_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        response = self.get_req("stp_config", request_body)
+        response_body = response.json()
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+        self.assertEqual(request_body["loop_guard"], response_body["loop_guard"])
+
+        # delete stp config
+        response = self.del_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        # get stp config
+        response = self.get_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_204_NO_CONTENT)
+
+    def test_stp_global_additional_parm_disabled_vlans_test(self):
+        device_ip = self.device_ips[0]
+
+        request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["PVST"],
+            "bpdu_filter": True,
+            "forwarding_delay": 10,
+            "hello_time": 10,
+            "max_age": 10,
+            "disabled_vlans": [100, 200],
+            "bridge_priority": 4096
+        }
+
+        # delete stp config
+        response = self.del_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        # get stp config
+        response = self.get_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_204_NO_CONTENT)
+
+        # create stp config
+        response = self.put_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        response = self.get_req("stp_config", request_body)
+        response_body = response.json()
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+        self.assertEqual(request_body["disabled_vlans"], response_body["disabled_vlans"])
+        self.assertEqual(request_body["enabled_protocol"], response_body["enabled_protocol"])
+        self.assertEqual(request_body["bpdu_filter"], response_body["bpdu_filter"])
+        self.assertEqual(request_body["hello_time"], response_body["hello_time"])
+        self.assertEqual(request_body["max_age"], response_body["max_age"])
+        self.assertEqual(request_body["forwarding_delay"], response_body["forwarding_delay"])
+        self.assertEqual(request_body["bridge_priority"], response_body["bridge_priority"])
+
+        # updating disabled vlans
+
+        request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["PVST"],
+            "bpdu_filter": True,
+            "forwarding_delay": 10,
+            "hello_time": 10,
+            "max_age": 10,
+            "disabled_vlans": [300],
+            "bridge_priority": 4096
+        }
+
+        # update stp config
+        response = self.put_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        response = self.get_req("stp_config", request_body)
+        response_body = response.json()
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+        self.assertTrue(300 in response_body["disabled_vlans"])
+
+        # delete stp config
+        response = self.del_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        # get stp config
+        response = self.get_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_204_NO_CONTENT)
+
+    def test_stp_global_deleted_disabled_vlans(self):
+        device_ip = self.device_ips[0]
+        vlan_1_name = "Vlan3"
+        vlan_1_id = 3
+        vlan_2_name = "Vlan4"
+        vlan_2_id = 4
+        vlan_3_name = "Vlan5"
+        vlan_3_id = 5
+
+        # deleting vlans from device to test disabled vlans.
+        # vlan not in device can be added as disabled vlans
+        response = self.del_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_2_name})
+        self.assertTrue(
+            response.status_code == status.HTTP_200_OK
+            or any(
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
+                if res != "\n"
+            )
+        )
+        response = self.get_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_2_name})
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        response = self.del_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name})
+        self.assertTrue(
+            response.status_code == status.HTTP_200_OK
+            or any(
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
+                if res != "\n"
+            )
+        )
+        response = self.get_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name})
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        response = self.del_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_3_name})
+        self.assertTrue(
+            response.status_code == status.HTTP_200_OK
+            or any(
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
+                if res != "\n"
+            )
+        )
+        response = self.get_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_3_name})
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["PVST"],
+            "bpdu_filter": True,
+            "forwarding_delay": 10,
+            "hello_time": 10,
+            "max_age": 10,
+            "disabled_vlans": [vlan_1_id, vlan_2_id, vlan_3_id],
+            "bridge_priority": 4096
+        }
+
+        # delete stp config
+        response = self.del_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        # get stp config
+        response = self.get_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_204_NO_CONTENT)
+
+        # create stp config
+        response = self.put_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        response = self.get_req("stp_config", request_body)
+        response_body = response.json()
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+        self.assertEqual(request_body["disabled_vlans"], response_body["disabled_vlans"])
+        self.assertEqual(request_body["enabled_protocol"], response_body["enabled_protocol"])
+        self.assertEqual(request_body["bpdu_filter"], response_body["bpdu_filter"])
+        self.assertEqual(request_body["hello_time"], response_body["hello_time"])
+        self.assertEqual(request_body["max_age"], response_body["max_age"])
+        self.assertEqual(request_body["forwarding_delay"], response_body["forwarding_delay"])
+        self.assertEqual(request_body["bridge_priority"], response_body["bridge_priority"])
+
+        # configuring disabled vlans to delete disabled vlans
+        req_payload = [
+            {
+                "mgt_ip": device_ip,
+                "name": vlan_1_name,
+                "vlanid": vlan_1_id,
+                "mtu": 9000,
+                "enabled": False,
+                "description": "Test_Vlan1",
+            },
+            {
+                "mgt_ip": device_ip,
+                "name": vlan_2_name,
+                "vlanid": vlan_2_id,
+                "mtu": 9000,
+                "enabled": False,
+                "description": "Test_Vlan2",
+            }
+        ]
+
+        response = self.put_req(
+            "vlan_config",
+            req_payload,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Testing whether vlans are added or not
+        response = self.get_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["vlanid"], vlan_1_id)
+        self.assertEqual(response.json()["name"], vlan_1_name)
+        response = self.get_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_2_name})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["vlanid"], vlan_2_id)
+        self.assertEqual(response.json()["name"], vlan_2_name)
+
+        response_body = {
+            "mgt_ip": device_ip,
+            "disabled_vlans": [vlan_1_id, vlan_2_id],
+        }
+
+        # Test deleting diabled_vlans
+        response = self.del_req("stp_delete_disabled_vlans", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        response = self.get_req("stp_config", response_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        response_body = response.json()
+        self.assertTrue(vlan_3_id in response_body["disabled_vlans"])
+        self.assertTrue(vlan_1_id not in response_body["disabled_vlans"])
+        self.assertTrue(vlan_2_id not in response_body["disabled_vlans"])
+
+        # clean up
+        response = self.del_req(
+            "vlan_config", {"mgt_ip": device_ip, "name": vlan_2_name}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.get_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_2_name})
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        response = self.del_req(
+            "vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.get_req("vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name})
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # delete stp config
+        response = self.del_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        # get stp config
+        response = self.get_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_204_NO_CONTENT)

--- a/network/urls.py
+++ b/network/urls.py
@@ -3,9 +3,11 @@
 from django.urls import re_path, path
 
 from . import views
-from . import vlan, interface, port_chnl, mclag, bgp, port_group
+from . import vlan, interface, port_chnl, mclag, bgp, port_group, stp
 
 urlpatterns = [
+    path("stp", stp.stp_global_config, name="stp_config"),
+    path("stp_delete_disabled_vlans", stp.delete_disabled_vlans, name="stp_delete_disabled_vlans"),
     re_path("del_db", views.delete_db, name="del_db"),
     re_path("discover", views.discover, name="discover"),
     re_path("devices", views.device_list, name="device"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ djangorestframework = "^3.14.0"
 django-cors-headers = "^3.14.0"
 pytest = "^7.3.2"
 pytest-django = "^4.7.0"
-orca-nw-lib = "^1.3.21"
+orca-nw-lib = "^1.3.22"
 packaging = "^23.2"# Because of langchain dependencies in ORCASK, packaging should not be greater than 23.y.z.
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Issues:

STP (Spanning Tree Protocol) Configuration -

- Global STP config will be a new node in DB, so a new model created with the properties received as GET operation at the path described in above cell.

- The new node stp will have a "HAS" relation with its Device node in the DB.

- A respective stp.py stp_db.py stp_gnmi.py needs to be created, Also discovery of STP global mechanism needed to be integrated in discovery.py

- orca_backend should provide CRUD rest endpoints for above.

- test cases covering operations on all the parameters.


Fixes issues:

- Added new db to save stp global configurations with has realtionship on device.
- orca_backend to support crud opetaions
- stp config added to discover and new files stp.py, stp_db.py, stp_gnmi.py are created.
- test cases for crud operations and parameters updates.
- api to delete disabled vlans.