### PR TITLE
STP Port Config #60

### DIFF
--- a/network/stp_port.py
+++ b/network/stp_port.py
@@ -12,7 +12,30 @@ from orca_nw_lib.stp_port import add_stp_port_members, get_stp_port_members, del
 @api_view(["PUT", "GET", "DELETE"])
 @log_request
 def stp_port_config(request):
-    """"""
+    """
+
+    Args:
+        request (Request): The request object.
+
+    Returns:
+        Response: The response object containing the result of the function.
+
+    Input put request body details:
+    mgt_ip (str, Required): The IP address of the device.
+    if_name (str, Required): The name of the interface.
+    bpdu_guard (bool, Required): Enable/Disable BPDU guard. Valid Values: True, False.
+    uplink_fast (bool, Required): Enable/Disable uplink fast. Valid Values: True, False.
+    stp_enabled (bool, Required): Enable/Disable STP. Valid Values: True, False.
+    edge_port (str): The name of the edge port. Valid Values: EDGE_AUTO, EDGE_ENABLE, EDGE_DISABLE.
+    link_type (str): The type of the link. Valid Values: P2P, SHARED.
+    guard (str): The guard. Valid Values: NONE, ROOT, LOOP.
+    bpdu_filter (bool): Enable/Disable BPDU filter. Valid Values: True, False.
+    portfast (bool): Enable/Disable portfast. Valid Values: True, False.
+    bpdu_guard_port_shutdown (bool): Enable/Disable BPDU guard port shutdown. Valid Values: True, False.
+    cost (int): The cost. Valid Range: 1-200000000.
+    port_priority (int): The port priority. Valid Range: 0-240.
+
+    """
     result = []
     http_status = True
     if request.method == "GET":
@@ -37,23 +60,42 @@ def stp_port_config(request):
                     {"status": "Required field device mgt_ip not found."},
                     status=status.HTTP_400_BAD_REQUEST,
                 )
+
             if_name = req_data.get("if_name", None)
             if not if_name:
                 return Response(
                     {"status": "Required field if_name not found."},
                     status=status.HTTP_400_BAD_REQUEST,
                 )
+
+            bpdu_guard = req_data.get("bpdu_guard", None)
+            if bpdu_guard is None:
+                return Response(
+                    {"status": "Required field bpdu_guard not found."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            uplink_fast = req_data.get("uplink_fast", None)
+            if uplink_fast is None:
+                return Response(
+                    {"status": "Required field uplink_fast not found."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            stp_enabled = req_data.get("stp_enabled", None)
+            if stp_enabled is None:
+                return Response(
+                    {"status": "Required field stp_enabled not found."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
             edge_port = req_data.get("edge_port", None)
             link_type = req_data.get("link_type", None)
             guard = req_data.get("guard", None)
-            bpdu_guard = req_data.get("bpdu_guard", None)
             bpdu_filter = req_data.get("bpdu_filter", None)
             port_fast = req_data.get("portfast", None)
-            uplink_fast = req_data.get("uplink_fast", None)
             bpdu_guard_port_shutdown = req_data.get("bpdu_guard_port_shutdown", None)
             cost = req_data.get("cost", None)
             port_priority = req_data.get("port_priority", None)
-            stp_enabled = req_data.get("stp_enabled", None)
             try:
                 add_stp_port_members(
                     device_ip=device_ip,
@@ -99,7 +141,17 @@ def stp_port_config(request):
 @api_view(["PUT"])
 @log_request
 def stp_discovery(request):
-    """"""
+    """
+
+    Args:
+        request (Request): The request object.
+
+    Returns:
+        Response: The response object containing the result of the function.
+
+    Input put request body details:
+    mgt_ip (str, Optional): The IP address of the device.
+    """
     result = []
     http_status = True
     for req_data in (request.data if isinstance(request.data, list) else [request.data] if request.data else []):

--- a/network/stp_port.py
+++ b/network/stp_port.py
@@ -114,8 +114,6 @@ def stp_port_config(request):
                 )
                 add_msg_to_list(result, get_success_msg(request))
             except Exception as err:
-                import traceback
-                print(traceback.format_exc())
                 add_msg_to_list(result, get_failure_msg(err, request))
                 http_status = http_status and False
         if request.method == "DELETE":

--- a/network/stp_port.py
+++ b/network/stp_port.py
@@ -1,0 +1,95 @@
+from rest_framework import status
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+from log_manager.decorators import log_request
+from network.util import add_msg_to_list, get_success_msg, get_failure_msg
+from orca_nw_lib.common import STPPortEdgePort, STPPortLinkType, STPPortGuard
+from orca_nw_lib.stp_port import add_stp_port_members, get_stp_port_members, delete_stp_port_member
+
+
+@api_view(["PUT", "GET", "DELETE"])
+@log_request
+def stp_port_config(request):
+    """"""
+    result = []
+    http_status = True
+    if request.method == "GET":
+        device_ip = request.GET.get("mgt_ip", "")
+        if not device_ip:
+            return Response(
+                {"status": "Required field device mgt_ip not found."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if_name = request.GET.get("if_name", None)
+        data = get_stp_port_members(device_ip, if_name)
+        return (
+            Response(data, status=status.HTTP_200_OK)
+            if data
+            else Response({}, status=status.HTTP_204_NO_CONTENT)
+        )
+    for req_data in (request.data if isinstance(request.data, list) else [request.data] if request.data else []):
+        if request.method == "PUT":
+            device_ip = req_data.get("mgt_ip", "")
+            if not device_ip:
+                return Response(
+                    {"status": "Required field device mgt_ip not found."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            if_name = req_data.get("if_name", None)
+            if not if_name:
+                return Response(
+                    {"status": "Required field if_name not found."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            edge_port = req_data.get("edge_port", None)
+            link_type = req_data.get("link_type", None)
+            guard = req_data.get("guard", None)
+            bpdu_guard = req_data.get("bpdu_guard", None)
+            bpdu_filter = req_data.get("bpdu_filter", None)
+            port_fast = req_data.get("portfast", None)
+            uplink_fast = req_data.get("uplink_fast", None)
+            bpdu_guard_port_shutdown = req_data.get("bpdu_guard_port_shutdown", None)
+            cost = req_data.get("cost", None)
+            port_priority = req_data.get("port_priority", None)
+            stp_enabled = req_data.get("stp_enabled", None)
+            try:
+                add_stp_port_members(
+                    device_ip=device_ip,
+                    if_name=if_name,
+                    edge_port=STPPortEdgePort.get_enum_from_str(edge_port) if edge_port else None,
+                    link_type=STPPortLinkType.get_enum_from_str(link_type)if link_type else None,
+                    guard=STPPortGuard.get_enum_from_str(guard) if guard else None,
+                    bpdu_guard=bpdu_guard,
+                    bpdu_filter=bpdu_filter,
+                    portfast=port_fast,
+                    uplink_fast=uplink_fast,
+                    bpdu_guard_port_shutdown=bpdu_guard_port_shutdown,
+                    cost=cost,
+                    port_priority=port_priority,
+                    stp_enabled=stp_enabled,
+                )
+                add_msg_to_list(result, get_success_msg(request))
+            except Exception as err:
+                import traceback
+                print(traceback.format_exc())
+                add_msg_to_list(result, get_failure_msg(err, request))
+                http_status = http_status and False
+        if request.method == "DELETE":
+            device_ip = req_data.get("mgt_ip", "")
+            if not device_ip:
+                return Response(
+                    {"status": "Required field device mgt_ip not found."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            if_name = req_data.get("if_name", None)
+            try:
+                delete_stp_port_member(device_ip=device_ip, if_name=if_name)
+                add_msg_to_list(result, get_success_msg(request))
+            except Exception as err:
+                add_msg_to_list(result, get_failure_msg(err, request))
+                http_status = http_status and False
+    return Response(
+        {"result": result},
+        status=(status.HTTP_200_OK if http_status else status.HTTP_500_INTERNAL_SERVER_ERROR),
+    )

--- a/network/test/test_common.py
+++ b/network/test/test_common.py
@@ -390,7 +390,7 @@ class TestORCA(APITestCase):
                         else:
                             self.assertEqual(response.status_code, value)
                         continue ## Continue with next key
-                    
+
                     if response.status_code == status.HTTP_200_OK:
                         print(f"Received: {key}={response.json()[key]}")
                         self.assertEqual(response.json()[key], value)
@@ -399,12 +399,25 @@ class TestORCA(APITestCase):
                 print(
                     f"Assertion failed for request args: {req_args}, and assert args: {assert_args}"
                 )
-                print(f"Response: {response.json()}")
+                print(f"Response: {response.content}")
                 print(f"Retrying in {timeout} seconds")
                 time.sleep(timeout)
                 if i == retries:
                     raise ## If even after retries, assertion still fails, raise the exception
-        
+
+    def assert_response_status_with_retry_and_timeout(self, response, expected_status_codes, expected_response_msg=None):
+        timeout = 2
+        retries = 5
+        for i in range(retries + 1):
+            try:
+                self.assert_response_status(response, expected_status_codes, expected_response_msg)
+            except AssertionError:
+                print(f"Retrying in {timeout} seconds")
+                time.sleep(timeout)
+                if i == retries:
+                    raise
+
+
 
     def remove_mclag(self, device_ip):
         response = self.del_req("device_mclag_list", {"mgt_ip": device_ip})

--- a/network/test/test_delete_db.py
+++ b/network/test/test_delete_db.py
@@ -24,15 +24,18 @@ class TestDelete(TestORCA):
             "mgt_ip": self.device_ips[0],
         }
         response=self.del_req("del_db", request_body)
-        self.assertTrue(response.status_code ==  status.HTTP_200_OK) 
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
         
         # get discover device after deletion
         response=self.get_req("device")
-        self.assertTrue(response.status_code == status.HTTP_200_OK)
-        
-        # storing count in variable for compaction
-        count_after_delete = len(response.json())
-        
+        if len(set(self.device_ips)) > 1:
+            self.assertTrue(response.status_code == status.HTTP_200_OK)
+            # storing count in variable for compaction
+            count_after_delete = len(response.json())
+        else:
+            self.assertTrue(response.status_code == status.HTTP_204_NO_CONTENT)
+            count_after_delete = 0
+
         # checking if the counts are correct 
         # i. e device before deletion must be one grater than device after deletion
         self.assertEqual(count_before_delete, count_after_delete + 1)

--- a/network/test/test_stp_port.py
+++ b/network/test/test_stp_port.py
@@ -1,0 +1,1061 @@
+import time
+
+from rest_framework import status
+
+from network.test.test_common import TestORCA
+
+
+class TestSTPPort(TestORCA):
+    """
+    This module contains tests for the STP API.
+    """
+
+    def perform_add_stp_global(self, request_body):
+        # create stp config
+        response = self.put_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        response = self.get_req("stp_config", request_body)
+        response_body = response.json()[0]
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+        self.assertEqual(request_body["enabled_protocol"], response_body["enabled_protocol"])
+        self.assertEqual(request_body["bpdu_filter"], response_body["bpdu_filter"])
+        self.assertEqual(request_body["hello_time"], response_body["hello_time"])
+        self.assertEqual(request_body["max_age"], response_body["max_age"])
+        self.assertEqual(request_body["forwarding_delay"], response_body["forwarding_delay"])
+        self.assertEqual(request_body["bridge_priority"], response_body["bridge_priority"])
+
+    def perform_delete_stp_global(self, request_body):
+        # delete stp config if it exists
+        response = self.del_req("stp_config", request_body)
+        self.assertTrue(
+            response.status_code == status.HTTP_200_OK
+            or any(
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
+                if res != "\n"
+            )
+        )
+
+        # get stp config
+        response = self.get_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_204_NO_CONTENT)
+
+    def perform_add_stp_port(self, request_body):
+
+        response = self.put_req("stp_port", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+        for i in request_body if isinstance(request_body, list) else [request_body]:
+            # Call with timeout because subscription response isn't recevied in time.
+            self.assert_with_timeout_retry(
+                lambda path, payload: self.get_req(path, payload),
+                "stp_port",
+                i,
+                status=status.HTTP_200_OK,
+                if_name=i["if_name"],
+                stp_enabled=i["stp_enabled"],
+                bpdu_guard=i["bpdu_guard"],
+                uplink_fast=i["uplink_fast"],
+            )
+
+    def perform_delete_stp_port(self, request_body):
+        while True:
+            del_response = self.del_req("stp_port", request_body)
+            if any(
+                "device is not ready to receive gnmi updates" in res.get("message", "").lower()
+                for res in del_response.json()["result"]
+                if res != "\n"
+            ):
+                time.sleep(5)
+            else:
+                break
+
+        self.assertTrue(
+            del_response.status_code == status.HTTP_200_OK
+            or any(
+                "resource not found" in res.get("message", "").lower()
+                for res in del_response.json()["result"]
+                if res != "\n"
+            )
+        )
+
+        self.assert_with_timeout_retry(
+            lambda path, payload: self.get_req(path, payload),
+            "stp_port",
+            request_body,
+            status=status.HTTP_204_NO_CONTENT,
+        )
+
+    def test_stp_port_config(self):
+        device_ip = self.device_ips[0]
+
+        # adding interface member
+        ether_1 = self.ether_names[0]
+        itf_request_body = [
+            {
+                "mgt_ip": device_ip,
+                "name": ether_1,
+                "mtu": 9100,
+            },
+        ]
+        self.assert_with_timeout_retry(
+            lambda path, payload: self.put_req(path, payload),
+            "device_interface_list",
+            itf_request_body,
+            status=status.HTTP_200_OK,
+        )
+
+        # adding port channel
+        port_channel_1 = "PortChannel104"
+        port_channel_request_body = {
+            "mgt_ip": device_ip,
+            "lag_name": port_channel_1,
+            "mtu": 9100,
+            "admin_status": "up"
+        }
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel_1})
+
+        # adding port channel
+        self.perform_add_port_chnl([port_channel_request_body])
+
+        # adding stp config
+        device_ip = self.device_ips[0]
+        stp_global_request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["PVST"],
+            "bpdu_filter": True,
+            "forwarding_delay": 10,
+            "hello_time": 10,
+            "max_age": 10,
+            "bridge_priority": 4096
+        }
+
+        # deleting stp global config
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+        # adding stp global config
+        self.perform_add_stp_global(request_body=stp_global_request_body)
+
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "if_name": port_channel_1,
+                "bpdu_guard": True,
+                "uplink_fast": True,
+                "stp_enabled": True,
+            },
+            {
+                "mgt_ip": device_ip,
+                "if_name": ether_1,
+                "bpdu_guard": True,
+                "uplink_fast": True,
+                "stp_enabled": True,
+            },
+        ]
+
+        # deleting stp port config
+        for i in request_body:
+            self.perform_delete_stp_port(request_body=i)
+
+        # testing adding stp port config
+        self.perform_add_stp_port(request_body=request_body)
+
+        # clean up
+        response = self.del_req("device_interface_list", itf_request_body)
+        self.assertTrue(
+            response.status_code == status.HTTP_200_OK
+            or any(
+                "resource not found" in res.get("message", "").lower() for res in response.json()["result"]
+                if res != "\n"
+            )
+        )
+
+        # deleting stp port config
+        for i in request_body:
+            self.perform_delete_stp_port(request_body=i)
+        self.perform_del_port_chnl(request_body=port_channel_request_body)
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+    def test_stp_port_bpdu_guard(self):
+        device_ip = self.device_ips[0]
+
+        # adding port channel
+        port_channel_1 = "PortChannel104"
+        port_channel_request_body = {
+            "mgt_ip": device_ip,
+            "lag_name": port_channel_1,
+            "mtu": 9100,
+            "admin_status": "up"
+        }
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel_1})
+
+        # adding port channel
+        self.perform_add_port_chnl([port_channel_request_body])
+
+        # adding stp config
+        device_ip = self.device_ips[0]
+        stp_global_request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["MSTP"],
+            "bpdu_filter": True,
+            "forwarding_delay": 10,
+            "hello_time": 10,
+            "max_age": 10,
+            "bridge_priority": 4096
+        }
+
+        # deleting stp global config
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+        # adding stp global config
+        self.perform_add_stp_global(request_body=stp_global_request_body)
+
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "if_name": port_channel_1,
+                "bpdu_guard": True,
+                "uplink_fast": True,
+                "stp_enabled": True,
+            }
+        ]
+
+        # deleting stp port config
+        for i in request_body:
+            self.perform_delete_stp_port(request_body=i)
+
+        # testing adding stp port config
+        self.perform_add_stp_port(request_body=request_body)
+
+        # update bpdu guard to false
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "if_name": port_channel_1,
+                "bpdu_guard": False,
+                "uplink_fast": True,
+                "stp_enabled": True,
+            }
+        ]
+        response = self.put_req("stp_port", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for i in request_body:
+            self.assert_with_timeout_retry(
+                lambda path, payload: self.get_req(path, payload),
+                "stp_port",
+                i,
+                status=status.HTTP_200_OK,
+                bpdu_guard=i["bpdu_guard"],
+                if_name=i["if_name"],
+            )
+
+        # clean up
+        for i in request_body:
+            self.perform_delete_stp_port(request_body=i)
+        self.perform_del_port_chnl(request_body=port_channel_request_body)
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+    def test_stp_port_bpdu_filter(self):
+        device_ip = self.device_ips[0]
+
+        # adding port channel
+        port_channel_1 = "PortChannel104"
+        port_channel_request_body = {
+            "mgt_ip": device_ip,
+            "lag_name": port_channel_1,
+            "mtu": 9100,
+            "admin_status": "up"
+        }
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel_1})
+
+        # adding port channel
+        self.perform_add_port_chnl([port_channel_request_body])
+
+        # adding stp config
+        device_ip = self.device_ips[0]
+        stp_global_request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["PVST"],
+            "bpdu_filter": True,
+            "forwarding_delay": 10,
+            "hello_time": 10,
+            "max_age": 10,
+            "bridge_priority": 4096
+        }
+
+        # deleting stp global config
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+        # adding stp global config
+        self.perform_add_stp_global(request_body=stp_global_request_body)
+
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "if_name": port_channel_1,
+                "bpdu_guard": True,
+                "uplink_fast": True,
+                "stp_enabled": True,
+            }
+        ]
+
+        # deleting stp port config
+        for i in request_body:
+            self.perform_delete_stp_port(request_body=i)
+
+        # testing adding stp port config
+        self.perform_add_stp_port(request_body=request_body)
+
+        # update bpdu filter to false
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "if_name": port_channel_1,
+                "bpdu_filter": False,
+                "bpdu_guard": True,
+                "uplink_fast": True,
+                "stp_enabled": True,
+            }
+        ]
+        response = self.put_req("stp_port", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for i in request_body:
+            self.assert_with_timeout_retry(
+                lambda path, payload: self.get_req(path, payload),
+                "stp_port",
+                i,
+                status=status.HTTP_200_OK,
+                bpdu_filter=i["bpdu_filter"],
+                if_name=i["if_name"],
+            )
+
+        # clean up
+        for i in request_body:
+            self.perform_delete_stp_port(request_body=i)
+        self.perform_del_port_chnl(request_body=port_channel_request_body)
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+    def test_stp_port_portfast(self):
+        device_ip = self.device_ips[0]
+
+        # adding port channel
+        port_channel_1 = "PortChannel104"
+        port_channel_request_body = {
+            "mgt_ip": device_ip,
+            "lag_name": port_channel_1,
+            "mtu": 9100,
+            "admin_status": "up"
+        }
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel_1})
+
+        # adding port channel
+        self.perform_add_port_chnl([port_channel_request_body])
+
+        # adding stp config
+        device_ip = self.device_ips[0]
+        stp_global_request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["PVST"],
+            "bpdu_filter": True,
+            "forwarding_delay": 10,
+            "hello_time": 10,
+            "max_age": 10,
+            "bridge_priority": 4096
+        }
+
+        # deleting stp global config
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+        # adding stp global config
+        self.perform_add_stp_global(request_body=stp_global_request_body)
+
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "if_name": port_channel_1,
+                "bpdu_guard": True,
+                "uplink_fast": True,
+                "stp_enabled": True,
+                "portfast": True
+            }
+        ]
+
+        # deleting stp port config
+        for i in request_body:
+            self.perform_delete_stp_port(request_body=i)
+
+        # testing adding stp port config
+        self.perform_add_stp_port(request_body=request_body)
+
+        # update portfast to false
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "if_name": port_channel_1,
+                "portfast": False,
+                "bpdu_guard": True,
+                "uplink_fast": True,
+                "stp_enabled": True,
+            }
+        ]
+        response = self.put_req("stp_port", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for i in request_body:
+            self.assert_with_timeout_retry(
+                lambda path, payload: self.get_req(path, payload),
+                "stp_port",
+                i,
+                status=status.HTTP_200_OK,
+                portfast=i["portfast"],
+                if_name=i["if_name"],
+            )
+
+        # clean up
+        for i in request_body:
+            self.perform_delete_stp_port(request_body=i)
+        self.perform_del_port_chnl(request_body=port_channel_request_body)
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+    def test_stp_port_uplink_fast(self):
+        device_ip = self.device_ips[0]
+
+        # adding port channel
+        port_channel_1 = "PortChannel104"
+        port_channel_request_body = {
+            "mgt_ip": device_ip,
+            "lag_name": port_channel_1,
+            "mtu": 9100,
+            "admin_status": "up"
+        }
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel_1})
+
+        # adding port channel
+        self.perform_add_port_chnl([port_channel_request_body])
+
+        # adding stp config
+        device_ip = self.device_ips[0]
+        stp_global_request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["PVST"],
+            "bpdu_filter": True,
+            "forwarding_delay": 10,
+            "hello_time": 10,
+            "max_age": 10,
+            "bridge_priority": 4096
+        }
+
+        # deleting stp global config
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+        # adding stp global config
+        self.perform_add_stp_global(request_body=stp_global_request_body)
+
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "if_name": port_channel_1,
+                "bpdu_guard": True,
+                "uplink_fast": True,
+                "stp_enabled": True,
+            }
+        ]
+
+        # deleting stp port config
+        for i in request_body:
+            self.perform_delete_stp_port(request_body=i)
+
+        # testing adding stp port config
+        self.perform_add_stp_port(request_body=request_body)
+
+        # update uplink_fast to false
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "if_name": port_channel_1,
+                "uplink_fast": False,
+                "bpdu_guard": True,
+                "stp_enabled": True,
+            }
+        ]
+        response = self.put_req("stp_port", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for i in request_body:
+            self.assert_with_timeout_retry(
+                lambda path, payload: self.get_req(path, payload),
+                "stp_port",
+                i,
+                status=status.HTTP_200_OK,
+                uplink_fast=i["uplink_fast"],
+                if_name=i["if_name"],)
+
+        # clean up
+        for i in request_body:
+            self.perform_delete_stp_port(request_body=i)
+        self.perform_del_port_chnl(request_body=port_channel_request_body)
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+    def test_stp_port_stp_enabled(self):
+        device_ip = self.device_ips[0]
+
+        # adding port channel
+        port_channel_1 = "PortChannel104"
+        port_channel_request_body = {
+            "mgt_ip": device_ip,
+            "lag_name": port_channel_1,
+            "mtu": 9100,
+            "admin_status": "up"
+        }
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel_1})
+
+        # adding port channel
+        self.perform_add_port_chnl([port_channel_request_body])
+
+        # adding stp config
+        device_ip = self.device_ips[0]
+        stp_global_request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["PVST"],
+            "bpdu_filter": True,
+            "forwarding_delay": 10,
+            "hello_time": 10,
+            "max_age": 10,
+            "bridge_priority": 4096
+        }
+
+        # deleting stp global config
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+        # adding stp global config
+        self.perform_add_stp_global(request_body=stp_global_request_body)
+
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "if_name": port_channel_1,
+                "bpdu_guard": True,
+                "uplink_fast": True,
+                "stp_enabled": True,
+            }
+        ]
+
+        # deleting stp port config
+        for i in request_body:
+            self.perform_delete_stp_port(request_body=i)
+
+        # testing adding stp port config
+        self.perform_add_stp_port(request_body=request_body)
+
+        # update stp_enabled to false
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "if_name": port_channel_1,
+                "stp_enabled": False,
+                "bpdu_guard": True,
+                "uplink_fast": True,
+            }
+        ]
+        response = self.put_req("stp_port", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for i in request_body:
+            self.assert_with_timeout_retry(
+                lambda path, payload: self.get_req(path, payload),
+                "stp_port",
+                i,
+                status=status.HTTP_200_OK,
+                stp_enabled=i["stp_enabled"],
+                if_name=i["if_name"],
+            )
+
+        # clean up
+        for i in request_body:
+            self.perform_delete_stp_port(request_body=i)
+        self.perform_del_port_chnl(request_body=port_channel_request_body)
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+    def test_stp_port_edge_port(self):
+        device_ip = self.device_ips[0]
+
+        # adding port channel
+        port_channel_1 = "PortChannel104"
+        port_channel_request_body = {
+            "mgt_ip": device_ip,
+            "lag_name": port_channel_1,
+            "mtu": 9100,
+            "admin_status": "up"
+        }
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel_1})
+
+        # adding port channel
+        self.perform_add_port_chnl([port_channel_request_body])
+
+        # adding stp config
+        device_ip = self.device_ips[0]
+        stp_global_request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["MSTP"],
+            "bpdu_filter": True,
+            "forwarding_delay": 10,
+            "hello_time": 10,
+            "max_age": 10,
+            "bridge_priority": 4096
+        }
+
+        # deleting stp global config
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+        # adding stp global config
+        self.perform_add_stp_global(request_body=stp_global_request_body)
+
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "if_name": port_channel_1,
+                "bpdu_guard": True,
+                "uplink_fast": True,
+                "stp_enabled": True,
+                "edge_port": "EDGE_AUTO"
+            }
+        ]
+
+        # deleting stp port config
+        for i in request_body:
+            self.perform_delete_stp_port(request_body=i)
+
+        # testing adding stp port config
+        self.perform_add_stp_port(request_body=request_body)
+
+        # update edge_port to EDGE_DISABLE
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "if_name": port_channel_1,
+                "edge_port": "EDGE_DISABLE",
+                "bpdu_guard": True,
+                "uplink_fast": True,
+                "stp_enabled": True,
+            }
+        ]
+        response = self.put_req("stp_port", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for i in request_body:
+            self.assert_with_timeout_retry(
+                lambda path, payload: self.get_req(path, payload),
+                "stp_port",
+                i,
+                status=status.HTTP_200_OK,
+                if_name=i["if_name"],
+                edge_port=i["edge_port"],
+            )
+
+        # clean up
+        for i in request_body:
+            self.perform_delete_stp_port(request_body=i)
+        self.perform_del_port_chnl(request_body=port_channel_request_body)
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+    def test_stp_port_link_type(self):
+        device_ip = self.device_ips[0]
+
+        # adding port channel
+        port_channel_1 = "PortChannel104"
+        port_channel_request_body = {
+            "mgt_ip": device_ip,
+            "lag_name": port_channel_1,
+            "mtu": 9100,
+            "admin_status": "up"
+        }
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel_1})
+
+        # adding port channel
+        self.perform_add_port_chnl([port_channel_request_body])
+
+        # adding stp config
+        device_ip = self.device_ips[0]
+        stp_global_request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["MSTP"],
+            "bpdu_filter": True,
+            "forwarding_delay": 10,
+            "hello_time": 10,
+            "max_age": 10,
+            "bridge_priority": 4096
+        }
+
+        # deleting stp global config
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+        # adding stp global config
+        self.perform_add_stp_global(request_body=stp_global_request_body)
+
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "if_name": port_channel_1,
+                "bpdu_guard": True,
+                "uplink_fast": True,
+                "stp_enabled": True,
+                "link_type": "P2P"
+            }
+        ]
+
+        # deleting stp port config
+        for i in request_body:
+            self.perform_delete_stp_port(request_body=i)
+
+        # testing adding stp port config
+        self.perform_add_stp_port(request_body=request_body)
+
+        # update link_type to SHARED
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "if_name": port_channel_1,
+                "bpdu_guard": True,
+                "uplink_fast": True,
+                "stp_enabled": True,
+                "link_type": "SHARED"
+            }
+        ]
+        response = self.put_req("stp_port", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for i in request_body:
+            self.assert_with_timeout_retry(
+                lambda path, payload: self.get_req(path, payload),
+                "stp_port",
+                i,
+                status=status.HTTP_200_OK,
+                if_name=i["if_name"],
+                link_type=i["link_type"],
+            )
+
+        # clean up
+        for i in request_body:
+            self.perform_delete_stp_port(request_body=i)
+        self.perform_del_port_chnl(request_body=port_channel_request_body)
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+    def test_stp_port_guard(self):
+        device_ip = self.device_ips[0]
+
+        # adding port channel
+        port_channel_1 = "PortChannel104"
+        port_channel_request_body = {
+            "mgt_ip": device_ip,
+            "lag_name": port_channel_1,
+            "mtu": 9100,
+            "admin_status": "up"
+        }
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel_1})
+
+        # adding port channel
+        self.perform_add_port_chnl([port_channel_request_body])
+
+        # adding stp config
+        device_ip = self.device_ips[0]
+        stp_global_request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["MSTP"],
+            "bpdu_filter": True,
+            "forwarding_delay": 10,
+            "hello_time": 10,
+            "max_age": 10,
+            "bridge_priority": 4096
+        }
+
+        # deleting stp global config
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+        # adding stp global config
+        self.perform_add_stp_global(request_body=stp_global_request_body)
+
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "if_name": port_channel_1,
+                "bpdu_guard": True,
+                "uplink_fast": True,
+                "stp_enabled": True,
+                "guard": "ROOT"
+            }
+        ]
+
+        # deleting stp port config
+        for i in request_body:
+            self.perform_delete_stp_port(request_body=i)
+
+        # testing adding stp port config
+        self.perform_add_stp_port(request_body=request_body)
+
+        # update guard to LOOP
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "if_name": port_channel_1,
+                "guard": "LOOP",
+                "bpdu_guard": True,
+                "uplink_fast": True,
+                "stp_enabled": True,
+
+            }
+        ]
+        response = self.put_req("stp_port", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for i in request_body:
+            self.assert_with_timeout_retry(
+                lambda path, payload: self.get_req(path, payload),
+                "stp_port",
+                i,
+                status=status.HTTP_200_OK,
+                if_name=i["if_name"],
+                guard=i["guard"],
+            )
+
+        # clean up
+        for i in request_body:
+            self.perform_delete_stp_port(request_body=i)
+        self.perform_del_port_chnl(request_body=port_channel_request_body)
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+    def test_stp_port_bpdu_guard_port_shutdown(self):
+        device_ip = self.device_ips[0]
+
+        # adding port channel
+        port_channel_1 = "PortChannel104"
+        port_channel_request_body = {
+            "mgt_ip": device_ip,
+            "lag_name": port_channel_1,
+            "mtu": 9100,
+            "admin_status": "up"
+        }
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel_1})
+
+        # adding port channel
+        self.perform_add_port_chnl([port_channel_request_body])
+
+        # adding stp config
+        device_ip = self.device_ips[0]
+        stp_global_request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["PVST"],
+            "bpdu_filter": True,
+            "forwarding_delay": 10,
+            "hello_time": 10,
+            "max_age": 10,
+            "bridge_priority": 4096
+        }
+
+        # deleting stp global config
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+        # adding stp global config
+        self.perform_add_stp_global(request_body=stp_global_request_body)
+
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "if_name": port_channel_1,
+                "bpdu_guard": True,
+                "uplink_fast": True,
+                "stp_enabled": True,
+                "bpdu_guard_port_shutdown": True
+            }
+        ]
+
+        # deleting stp port config
+        for i in request_body:
+            self.perform_delete_stp_port(request_body=i)
+
+        # testing adding stp port config
+        self.perform_add_stp_port(request_body=request_body)
+
+        # update bpdu_guard_port_shutdown to False
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "if_name": port_channel_1,
+                "bpdu_guard_port_shutdown": False,
+                "bpdu_guard": True,
+                "uplink_fast": True,
+                "stp_enabled": True,
+            }
+        ]
+        response = self.put_req("stp_port", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for i in request_body:
+            self.assert_with_timeout_retry(
+                lambda path, payload: self.get_req(path, payload),
+                "stp_port",
+                i,
+                status=status.HTTP_200_OK,
+                if_name=i["if_name"],
+                bpdu_guard_port_shutdown=i["bpdu_guard_port_shutdown"],
+            )
+
+        # clean up
+        for i in request_body:
+            self.perform_delete_stp_port(request_body=i)
+        self.perform_del_port_chnl(request_body=port_channel_request_body)
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+    def test_stp_port_cost(self):
+        device_ip = self.device_ips[0]
+
+        # adding port channel
+        port_channel_1 = "PortChannel104"
+        port_channel_request_body = {
+            "mgt_ip": device_ip,
+            "lag_name": port_channel_1,
+            "mtu": 9100,
+            "admin_status": "up"
+        }
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel_1})
+
+        # adding port channel
+        self.perform_add_port_chnl([port_channel_request_body])
+
+        # adding stp config
+        device_ip = self.device_ips[0]
+        stp_global_request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["PVST"],
+            "bpdu_filter": True,
+            "forwarding_delay": 10,
+            "hello_time": 10,
+            "max_age": 10,
+            "bridge_priority": 4096
+        }
+
+        # deleting stp global config
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+        # adding stp global config
+        self.perform_add_stp_global(request_body=stp_global_request_body)
+
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "if_name": port_channel_1,
+                "bpdu_guard": True,
+                "uplink_fast": True,
+                "stp_enabled": True,
+                "cost": 200
+            }
+        ]
+
+        # deleting stp port config
+        for i in request_body:
+            self.perform_delete_stp_port(request_body=i)
+
+        # testing adding stp port config
+        self.perform_add_stp_port(request_body=request_body)
+
+        # update cost to 500
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "if_name": port_channel_1,
+                "cost": 500,
+                "bpdu_guard": True,
+                "uplink_fast": True,
+                "stp_enabled": True,
+            }
+        ]
+        response = self.put_req("stp_port", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for i in request_body:
+            self.assert_with_timeout_retry(
+                lambda path, payload: self.get_req(path, payload),
+                "stp_port",
+                i,
+                status=status.HTTP_200_OK,
+                if_name=i["if_name"],
+                cost=i["cost"],
+            )
+
+        # clean up
+        for i in request_body:
+            self.perform_delete_stp_port(request_body=i)
+        self.perform_del_port_chnl(request_body=port_channel_request_body)
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+    def test_stp_port_port_priority(self):
+        device_ip = self.device_ips[0]
+
+        # adding port channel
+        port_channel_1 = "PortChannel104"
+        port_channel_request_body = {
+            "mgt_ip": device_ip,
+            "lag_name": port_channel_1,
+            "mtu": 9100,
+            "admin_status": "up"
+        }
+        self.perform_del_port_chnl({"mgt_ip": device_ip, "lag_name": port_channel_1})
+
+        # adding port channel
+        self.perform_add_port_chnl([port_channel_request_body])
+
+        # adding stp config
+        device_ip = self.device_ips[0]
+        stp_global_request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["PVST"],
+            "bpdu_filter": True,
+            "forwarding_delay": 10,
+            "hello_time": 10,
+            "max_age": 10,
+            "bridge_priority": 4096
+        }
+
+        # deleting stp global config
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+        # adding stp global config
+        self.perform_add_stp_global(request_body=stp_global_request_body)
+
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "if_name": port_channel_1,
+                "bpdu_guard": True,
+                "uplink_fast": True,
+                "stp_enabled": True,
+                "port_priority": 20
+            }
+        ]
+
+        # deleting stp port config
+        for i in request_body:
+            self.perform_delete_stp_port(request_body=i)
+
+        # testing adding stp port config
+        self.perform_add_stp_port(request_body=request_body)
+
+        # update port priority to 50
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "if_name": port_channel_1,
+                "port_priority": 50,
+                "bpdu_guard": True,
+                "uplink_fast": True,
+                "stp_enabled": True,
+            }
+        ]
+        response = self.put_req("stp_port", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for i in request_body:
+            self.assert_with_timeout_retry(
+                lambda path, payload: self.get_req(path, payload),
+                "stp_port",
+                i,
+                status=status.HTTP_200_OK,
+                if_name=i["if_name"],
+                port_priority=i["port_priority"],
+            )
+
+        # clean up
+        for i in request_body:
+            self.perform_delete_stp_port(request_body=i)
+        self.perform_del_port_chnl(request_body=port_channel_request_body)
+        self.perform_delete_stp_global(request_body=stp_global_request_body)

--- a/network/urls.py
+++ b/network/urls.py
@@ -2,12 +2,13 @@
 
 from django.urls import re_path, path
 
-from . import views
+from . import views, stp_port
 from . import vlan, interface, port_chnl, mclag, bgp, port_group, stp
 
 urlpatterns = [
     path("stp", stp.stp_global_config, name="stp_config"),
     path("stp_delete_disabled_vlans", stp.delete_disabled_vlans, name="stp_delete_disabled_vlans"),
+    path("stp_port", stp_port.stp_port_config, name="stp_port"),
     re_path("del_db", views.delete_db, name="del_db"),
     re_path("discover", views.discover, name="discover"),
     re_path("devices", views.device_list, name="device"),

--- a/network/urls.py
+++ b/network/urls.py
@@ -2,8 +2,7 @@
 
 from django.urls import re_path, path
 
-from . import views, stp_port
-from . import vlan, interface, port_chnl, mclag, bgp, port_group, stp
+from . import views, stp_port, vlan, interface, port_chnl, mclag, bgp, port_group, stp
 
 urlpatterns = [
     path("stp", stp.stp_global_config, name="stp_config"),

--- a/network/urls.py
+++ b/network/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path("stp", stp.stp_global_config, name="stp_config"),
     path("stp_delete_disabled_vlans", stp.delete_disabled_vlans, name="stp_delete_disabled_vlans"),
     path("stp_port", stp_port.stp_port_config, name="stp_port"),
+    path("stp_discovery", stp_port.stp_discovery, name="stp_discovery"),
     re_path("del_db", views.delete_db, name="del_db"),
     re_path("discover", views.discover, name="discover"),
     re_path("devices", views.device_list, name="device"),


### PR DESCRIPTION
Issues:

- STP Port Config - (orca_nw_lib) Payload and path are defined in SONiC Player Cell - "GET/SET/DELETE STP PORT"
config parameters received on get operation on the path should be updated during discovery in the vlan node already being created in DB. Wouldn't be bad to append stp_**** as prefix so that those parameters can be differentiated than other interface params.
- DB Updates (orca_nw_lib) - Interface specific path e.g. openconfig-spanning-tree:stp/interfaces/interface[name=Ethernet0]/config can be subscribed to receive notifications on any config change. Please note those subscriptions are interface specific which means subscription should be created for all interfaces for a device.
- orca_backend - REST end points to be updated.
- orca_backend - Respective Test cases covering CRUD operations on parameters.
- There should be an end-point resync (discover) STP global and port config not the complete device discovery, discovery function of STP from orca_nw_lib can be used for implementation.

Fixes: 
- created new files stp_port.py, stp_port_db.py, stp_port_gnmi.py.
- added new apis for crud operations in stp_port.
- added subscription both on delete and add.
- add new tests cases to test each parameter.
- added new stp_port db. Attched stp_port to device, portchannel, interface with has relation.

Note: put api first delete gnmi config and then creates gnmi config. This is done to trigger subscription.