### PR TITLE
STP Vlan Config. #59

### DIFF
--- a/network/stp_vlan.py
+++ b/network/stp_vlan.py
@@ -1,0 +1,89 @@
+from rest_framework import status
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+from log_manager.decorators import log_request
+from network.util import add_msg_to_list, get_success_msg, get_failure_msg
+from orca_nw_lib.stp_vlan import config_stp_vlan, get_stp_vlan, delete_stp_vlan
+
+
+@api_view(["GET", "PUT"])
+@log_request
+def stp_vlan_config(request):
+    """
+    Generates the function comment for the given function body.
+
+    Args:
+        request (Request): The request object.
+
+    Returns:
+        Response: The response object containing the result of the function.
+    """
+    result = []
+    http_status = True
+    if request.method == "GET":
+        device_ip = request.GET.get("mgt_ip", "")
+        if not device_ip:
+            return Response(
+                {"status": "Required field device mgt_ip not found."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        data = get_stp_vlan(
+            device_ip=device_ip,
+            vlan_id=request.GET.get("vlan_id", None)
+        )
+        return (
+            Response(data, status=status.HTTP_200_OK)
+            if data
+            else Response({}, status=status.HTTP_204_NO_CONTENT)
+        )
+    for req_data in (request.data if isinstance(request.data, list) else [request.data] if request.data else []):
+        if request.method == "PUT":
+            device_ip = req_data.get("mgt_ip", "")
+            if not device_ip:
+                return Response(
+                    {"status": "Required field device mgt_ip not found."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            vlan_id = req_data.get("vlan_id", "")
+            if not vlan_id:
+                return Response(
+                    {"status": "Required field vlan_id not found."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            try:
+                config_stp_vlan(
+                    device_ip=device_ip,
+                    vlan_id=vlan_id,
+                    bridge_priority=req_data.get("bridge_priority", None),
+                    forwarding_delay=req_data.get("forwarding_delay", None),
+                    hello_time=req_data.get("hello_time", None),
+                    max_age=req_data.get("max_age", None),
+                )
+                add_msg_to_list(result, get_success_msg(request))
+            except Exception as err:
+                add_msg_to_list(result, get_failure_msg(err, request))
+                http_status = http_status and False
+        # if request.method == "DELETE":
+        #     device_ip = req_data.get("mgt_ip", "")
+        #     if not device_ip:
+        #         return Response(
+        #             {"status": "Required field device mgt_ip not found."},
+        #             status=status.HTTP_400_BAD_REQUEST,
+        #         )
+        #     vlan_id = req_data.get("vlan_id", "")
+        #     if not vlan_id:
+        #         return Response(
+        #             {"status": "Required field vlan_id not found."},
+        #             status=status.HTTP_400_BAD_REQUEST,
+        #         )
+        #     try:
+        #         delete_stp_vlan(device_ip=device_ip, vlan_id=vlan_id)
+        #         add_msg_to_list(result, get_success_msg(request))
+        #     except Exception as err:
+        #         add_msg_to_list(result, get_failure_msg(err, request))
+        #         http_status = http_status and False
+    return Response(
+        {"result": result},
+        status=(status.HTTP_200_OK if http_status else status.HTTP_500_INTERNAL_SERVER_ERROR),
+    )

--- a/network/stp_vlan.py
+++ b/network/stp_vlan.py
@@ -4,7 +4,7 @@ from rest_framework.response import Response
 
 from log_manager.decorators import log_request
 from network.util import add_msg_to_list, get_success_msg, get_failure_msg
-from orca_nw_lib.stp_vlan import config_stp_vlan, get_stp_vlan, delete_stp_vlan
+from orca_nw_lib.stp_vlan import config_stp_vlan, get_stp_vlan
 
 
 @api_view(["GET", "PUT"])
@@ -64,25 +64,6 @@ def stp_vlan_config(request):
             except Exception as err:
                 add_msg_to_list(result, get_failure_msg(err, request))
                 http_status = http_status and False
-        # if request.method == "DELETE":
-        #     device_ip = req_data.get("mgt_ip", "")
-        #     if not device_ip:
-        #         return Response(
-        #             {"status": "Required field device mgt_ip not found."},
-        #             status=status.HTTP_400_BAD_REQUEST,
-        #         )
-        #     vlan_id = req_data.get("vlan_id", "")
-        #     if not vlan_id:
-        #         return Response(
-        #             {"status": "Required field vlan_id not found."},
-        #             status=status.HTTP_400_BAD_REQUEST,
-        #         )
-        #     try:
-        #         delete_stp_vlan(device_ip=device_ip, vlan_id=vlan_id)
-        #         add_msg_to_list(result, get_success_msg(request))
-        #     except Exception as err:
-        #         add_msg_to_list(result, get_failure_msg(err, request))
-        #         http_status = http_status and False
     return Response(
         {"result": result},
         status=(status.HTTP_200_OK if http_status else status.HTTP_500_INTERNAL_SERVER_ERROR),

--- a/network/test/test_stp_vlan.py
+++ b/network/test/test_stp_vlan.py
@@ -1,0 +1,571 @@
+from rest_framework import status
+
+from network.test.test_common import TestORCA
+
+
+class TestSTPVlan(TestORCA):
+
+    def perform_add_stp_global(self, request_body):
+        # create stp config
+        response = self.put_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+
+        response = self.get_req("stp_config", request_body)
+        response_body = response.json()[0]
+        self.assertTrue(response.status_code == status.HTTP_200_OK)
+        self.assertEqual(request_body["enabled_protocol"], response_body["enabled_protocol"])
+        self.assertEqual(request_body["bpdu_filter"], response_body["bpdu_filter"])
+        self.assertEqual(request_body["hello_time"], response_body["hello_time"])
+        self.assertEqual(request_body["max_age"], response_body["max_age"])
+        self.assertEqual(request_body["forwarding_delay"], response_body["forwarding_delay"])
+        self.assertEqual(request_body["bridge_priority"], response_body["bridge_priority"])
+
+    def perform_delete_stp_global(self, request_body):
+        # delete stp config if it exists
+        response = self.del_req("stp_config", request_body)
+        self.assertTrue(
+            response.status_code == status.HTTP_200_OK
+            or any(
+                "resource not found" in res.get("message", "").lower()
+                for res in response.json()["result"]
+                if res != "\n"
+            )
+        )
+
+        # get stp config
+        response = self.get_req("stp_config", request_body)
+        self.assertTrue(response.status_code == status.HTTP_204_NO_CONTENT)
+
+    def test_stp_vlan_config(self):
+        device_ip = self.device_ips[0]
+        vlan_1_name = "Vlan3"
+        vlan_1_id = 3
+        vlan_2_name = "Vlan4"
+        vlan_2_id = 4
+
+        req_payload = [
+            {
+                "mgt_ip": device_ip,
+                "name": vlan_1_name,
+                "vlanid": vlan_1_id,
+                "mtu": 9000,
+                "enabled": False,
+                "description": "Test_Vlan1",
+            },
+            {
+                "mgt_ip": device_ip,
+                "name": vlan_2_name,
+                "vlanid": vlan_2_id,
+                "mtu": 9000,
+                "enabled": False,
+                "description": "Test_Vlan2",
+            },
+        ]
+
+        response = self.put_req(
+            "vlan_config",
+            req_payload,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Testing whether vlans are added or not
+        response = self.get_req(
+            "vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["vlanid"], vlan_1_id)
+        self.assertEqual(response.json()["name"], vlan_1_name)
+        response = self.get_req(
+            "vlan_config", {"mgt_ip": device_ip, "name": vlan_2_name}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["vlanid"], vlan_2_id)
+        self.assertEqual(response.json()["name"], vlan_2_name)
+
+        # adding stp config
+        device_ip = self.device_ips[0]
+        stp_global_request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["PVST"],
+            "bpdu_filter": True,
+            "forwarding_delay": 10,
+            "hello_time": 10,
+            "max_age": 10,
+            "bridge_priority": 4096
+        }
+
+        # deleting stp global config
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+        # adding stp global config
+        self.perform_add_stp_global(request_body=stp_global_request_body)
+
+        # adding stp vlan
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "vlan_id": vlan_1_id,
+            },
+            {
+                "mgt_ip": device_ip,
+                "vlan_id": vlan_2_id,
+            },
+        ]
+
+        response = self.put_req("stp_vlan_config", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # validating stp vlan
+        response = self.get_req("stp_vlan_config", {"mgt_ip": device_ip, "vlan_id": vlan_1_id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["vlan_id"], vlan_1_id)
+
+        response = self.get_req("stp_vlan_config", {"mgt_ip": device_ip, "vlan_id": vlan_2_id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["vlan_id"], vlan_2_id)
+
+        # clean up
+
+        # deleting vlans
+        response = self.del_req(
+            "vlan_config", {"mgt_ip": device_ip, "name": vlan_2_name}
+        )
+        print(response.json())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.get_req(
+            "vlan_config", {"mgt_ip": device_ip, "name": vlan_2_name}
+        )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        response = self.del_req(
+            "vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.get_req(
+            "vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name}
+        )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # checking stp vlan config
+        response = self.get_req("stp_vlan_config", {"mgt_ip": device_ip, "vlan_id": vlan_1_id})
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        response = self.get_req("stp_vlan_config", {"mgt_ip": device_ip, "vlan_id": vlan_2_id})
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # deleting stp global config
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+    def test_stp_vlan_bridge_priority(self):
+        device_ip = self.device_ips[0]
+        vlan_1_name = "Vlan3"
+        vlan_1_id = 3
+
+        req_payload = [
+            {
+                "mgt_ip": device_ip,
+                "name": vlan_1_name,
+                "vlanid": vlan_1_id,
+                "mtu": 9000,
+                "enabled": False,
+                "description": "Test_Vlan1",
+            },
+        ]
+
+        response = self.put_req(
+            "vlan_config",
+            req_payload,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Testing whether vlans are added or not
+        response = self.get_req(
+            "vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["vlanid"], vlan_1_id)
+        self.assertEqual(response.json()["name"], vlan_1_name)
+
+        # adding stp config
+        device_ip = self.device_ips[0]
+        stp_global_request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["PVST"],
+            "bpdu_filter": True,
+            "forwarding_delay": 10,
+            "hello_time": 10,
+            "max_age": 10,
+            "bridge_priority": 4096
+        }
+
+        # deleting stp global config
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+        # adding stp global config
+        self.perform_add_stp_global(request_body=stp_global_request_body)
+
+        # adding stp vlan
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "vlan_id": vlan_1_id,
+                "bridge_priority": 4096
+            },
+        ]
+
+        response = self.put_req("stp_vlan_config", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # validating stp vlan
+        response = self.get_req("stp_vlan_config", {"mgt_ip": device_ip, "vlan_id": vlan_1_id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["vlan_id"], vlan_1_id)
+        self.assertEqual(response.json()["bridge_priority"], 4096)
+
+        # updating stp vlan
+
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "vlan_id": vlan_1_id,
+                "bridge_priority": 4096 * 2
+            },
+        ]
+
+        response = self.put_req("stp_vlan_config", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # validating stp vlan
+        response = self.get_req("stp_vlan_config", {"mgt_ip": device_ip, "vlan_id": vlan_1_id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["vlan_id"], vlan_1_id)
+        self.assertEqual(response.json()["bridge_priority"], 4096 * 2)
+
+        # clean up
+
+        # deleting vlans
+        response = self.del_req(
+            "vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.get_req(
+            "vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name}
+        )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # checking stp vlan config
+        response = self.get_req("stp_vlan_config", {"mgt_ip": device_ip, "vlan_id": vlan_1_id})
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # deleting stp global config
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+    def test_stp_vlan_forwarding_delay(self):
+        device_ip = self.device_ips[0]
+        vlan_1_name = "Vlan3"
+        vlan_1_id = 3
+
+        req_payload = [
+            {
+                "mgt_ip": device_ip,
+                "name": vlan_1_name,
+                "vlanid": vlan_1_id,
+                "mtu": 9000,
+                "enabled": False,
+                "description": "Test_Vlan1",
+            },
+        ]
+
+        response = self.put_req(
+            "vlan_config",
+            req_payload,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Testing whether vlans are added or not
+        response = self.get_req(
+            "vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["vlanid"], vlan_1_id)
+        self.assertEqual(response.json()["name"], vlan_1_name)
+
+        # adding stp config
+        device_ip = self.device_ips[0]
+        stp_global_request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["PVST"],
+            "bpdu_filter": True,
+            "forwarding_delay": 10,
+            "hello_time": 10,
+            "max_age": 10,
+            "bridge_priority": 4096
+        }
+
+        # deleting stp global config
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+        # adding stp global config
+        self.perform_add_stp_global(request_body=stp_global_request_body)
+
+        # adding stp vlan
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "vlan_id": vlan_1_id,
+                "forwarding_delay": 20
+            },
+        ]
+
+        response = self.put_req("stp_vlan_config", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # validating stp vlan
+        response = self.get_req("stp_vlan_config", {"mgt_ip": device_ip, "vlan_id": vlan_1_id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["vlan_id"], vlan_1_id)
+        self.assertEqual(response.json()["forwarding_delay"], 20)
+
+        # updating stp vlan
+
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "vlan_id": vlan_1_id,
+                "forwarding_delay": 21
+            },
+        ]
+
+        response = self.put_req("stp_vlan_config", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # validating stp vlan
+        response = self.get_req("stp_vlan_config", {"mgt_ip": device_ip, "vlan_id": vlan_1_id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["vlan_id"], vlan_1_id)
+        self.assertEqual(response.json()["forwarding_delay"], 21)
+
+        # clean up
+
+        # deleting vlans
+        response = self.del_req(
+            "vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.get_req(
+            "vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name}
+        )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # checking stp vlan config
+        response = self.get_req("stp_vlan_config", {"mgt_ip": device_ip, "vlan_id": vlan_1_id})
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # deleting stp global config
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+    def test_stp_vlan_hello_time(self):
+        device_ip = self.device_ips[0]
+        vlan_1_name = "Vlan3"
+        vlan_1_id = 3
+
+        req_payload = [
+            {
+                "mgt_ip": device_ip,
+                "name": vlan_1_name,
+                "vlanid": vlan_1_id,
+                "mtu": 9000,
+                "enabled": False,
+                "description": "Test_Vlan1",
+            },
+        ]
+
+        response = self.put_req(
+            "vlan_config",
+            req_payload,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Testing whether vlans are added or not
+        response = self.get_req(
+            "vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["vlanid"], vlan_1_id)
+        self.assertEqual(response.json()["name"], vlan_1_name)
+
+        # adding stp config
+        device_ip = self.device_ips[0]
+        stp_global_request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["PVST"],
+            "bpdu_filter": True,
+            "forwarding_delay": 10,
+            "hello_time": 10,
+            "max_age": 10,
+            "bridge_priority": 4096
+        }
+
+        # deleting stp global config
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+        # adding stp global config
+        self.perform_add_stp_global(request_body=stp_global_request_body)
+
+        # adding stp vlan
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "vlan_id": vlan_1_id,
+                "hello_time": 9
+            },
+        ]
+
+        response = self.put_req("stp_vlan_config", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # validating stp vlan
+        response = self.get_req("stp_vlan_config", {"mgt_ip": device_ip, "vlan_id": vlan_1_id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["vlan_id"], vlan_1_id)
+        self.assertEqual(response.json()["hello_time"], 9)
+
+        # updating stp vlan
+
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "vlan_id": vlan_1_id,
+                "hello_time": 2
+            },
+        ]
+
+        response = self.put_req("stp_vlan_config", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # validating stp vlan
+        response = self.get_req("stp_vlan_config", {"mgt_ip": device_ip, "vlan_id": vlan_1_id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["vlan_id"], vlan_1_id)
+        self.assertEqual(response.json()["hello_time"], 2)
+
+        # clean up
+
+        # deleting vlans
+        response = self.del_req(
+            "vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.get_req(
+            "vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name}
+        )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # checking stp vlan config
+        response = self.get_req("stp_vlan_config", {"mgt_ip": device_ip, "vlan_id": vlan_1_id})
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # deleting stp global config
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+    def test_stp_vlan_max_age(self):
+        device_ip = self.device_ips[0]
+        vlan_1_name = "Vlan3"
+        vlan_1_id = 3
+
+        req_payload = [
+            {
+                "mgt_ip": device_ip,
+                "name": vlan_1_name,
+                "vlanid": vlan_1_id,
+                "mtu": 9000,
+                "enabled": False,
+                "description": "Test_Vlan1",
+            },
+        ]
+
+        response = self.put_req(
+            "vlan_config",
+            req_payload,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Testing whether vlans are added or not
+        response = self.get_req(
+            "vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["vlanid"], vlan_1_id)
+        self.assertEqual(response.json()["name"], vlan_1_name)
+
+        # adding stp config
+        device_ip = self.device_ips[0]
+        stp_global_request_body = {
+            "mgt_ip": device_ip,
+            "enabled_protocol": ["PVST"],
+            "bpdu_filter": True,
+            "forwarding_delay": 10,
+            "hello_time": 10,
+            "max_age": 10,
+            "bridge_priority": 4096
+        }
+
+        # deleting stp global config
+        self.perform_delete_stp_global(request_body=stp_global_request_body)
+
+        # adding stp global config
+        self.perform_add_stp_global(request_body=stp_global_request_body)
+
+        # adding stp vlan
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "vlan_id": vlan_1_id,
+                "max_age": 11
+            },
+        ]
+
+        response = self.put_req("stp_vlan_config", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # validating stp vlan
+        response = self.get_req("stp_vlan_config", {"mgt_ip": device_ip, "vlan_id": vlan_1_id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["vlan_id"], vlan_1_id)
+        self.assertEqual(response.json()["max_age"], 11)
+
+        # updating stp vlan
+
+        request_body = [
+            {
+                "mgt_ip": device_ip,
+                "vlan_id": vlan_1_id,
+                "max_age": 20
+            },
+        ]
+
+        response = self.put_req("stp_vlan_config", request_body)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # validating stp vlan
+        response = self.get_req("stp_vlan_config", {"mgt_ip": device_ip, "vlan_id": vlan_1_id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["vlan_id"], vlan_1_id)
+        self.assertEqual(response.json()["max_age"], 20)
+
+        # clean up
+
+        # deleting vlans
+        response = self.del_req(
+            "vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.get_req(
+            "vlan_config", {"mgt_ip": device_ip, "name": vlan_1_name}
+        )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # checking stp vlan config
+        response = self.get_req("stp_vlan_config", {"mgt_ip": device_ip, "vlan_id": vlan_1_id})
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # deleting stp global config
+        self.perform_delete_stp_global(request_body=stp_global_request_body)

--- a/network/urls.py
+++ b/network/urls.py
@@ -2,7 +2,7 @@
 
 from django.urls import re_path, path
 
-from . import views
+from . import views, stp_vlan
 from . import vlan, interface, port_chnl, mclag, bgp, port_group, stp
 
 urlpatterns = [
@@ -12,6 +12,7 @@ urlpatterns = [
         stp.delete_disabled_vlans,
         name="stp_delete_disabled_vlans",
     ),
+    path("stp_vlan", stp_vlan.stp_vlan_config, name="stp_vlan_config"),
     re_path("del_db", views.delete_db, name="del_db"),
     re_path("discover", views.discover, name="discover"),
     re_path("devices", views.device_list, name="device"),


### PR DESCRIPTION
Issuess:

- STP VLAN Config - (orca_nw_lib) Payload and path are defined in SONiC Player Cell - "GET/SET/DELETE STP PVST VLAN"
config parameters received on get operation on the path should be updated during discovery in the vlan node already being created in DB. Wouldn't be bad to append stp_**** as prefix so that those parameters can be differentiated than other vlan params.
- DB Updates (orca_nw_lib) - Vlan specific path e.g. /openconfig-spanning-tree:stp/openconfig-spanning-tree-ext:pvst/vlans[vlan-id=6]/config can be subscribed to receive notifications on anyconfig change. Please note those subscriptions are vylan specific which means subscription should be created for already exiting vlans or newly created vlans and should be removed for vlan which are deleted.
- orca_backend - REST end points to be updated.
- orca_backend - Respective Test cases covering CRUD operations on parameters.

Fixes: 
- created new files stp_vlan.py, stp_vlan_db.py, stp_vlan_gnmi.py.
- added new apis for crud operations in stp_vlan.
- add new tests cases to test each parameter.
- added new stp_vlan db. Attched stp_vlan to device, vlan with has relation.