### PR TITLE
Docker orca_backend -Host Networking option not supported by default on Mac and Windows hence orca_backend is not reachable. #55

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,5 @@ EXPOSE 8000
 CMD python3 manage.py makemigrations log_manager && \
     python3 manage.py migrate && \
     export DJANGO_SUPERUSER_PASSWORD=admin && \
-    python manage.py createsuperuser --username=admin --email=admin@example.com --noinput && \
+    python manage.py createsuperuser --username=admin --email=admin@example.com --noinput || true && \
     python3 manage.py runserver 0.0.0.0:8000

--- a/README.md
+++ b/README.md
@@ -62,10 +62,16 @@ To check that neo4j has successfully started, open https://localhost:7474 with c
 
 ### Run orca_backend docker container
 Use following command to run orca_backend
+- If orca_backend is running on the same machine use below command:
+    ```sh
+    docker run --network=orca_container_network --name orca_backend -p 8000:8000 -e neo4j_url=orca_neo4j:7687 -d stordis/orca_backend:latest
+    ```
+- If neo4j is running on the different machine use below command:
+    ```sh
+    docker run --name orca_backend -p 8000:8000 -e neo4j_url="http://<neo4j_url:port>" -d stordis/orca_backend:latest
+    ```
 
-```sh
-docker run --network=orca_container_network --name orca_backend -p 8000:8000 -e neo4j_url=orca_neo4j:7687 -d stordis/orca_backend:latest
-```
+    If neo4j running on different machine replace `"http://<neo4j_url:port>"` with vm ip and port exposed for to neo4j. 
 
 Container runs on 0.0.0.0:8000 by default. To verify that container has successfully started, try to access http://<server_ip>:8000/admin/ and log in with default user/password- admin/admin which is by default created.
 

--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ Use following command to run orca_backend
     ```
 - If neo4j is running on the different machine use below command:
     ```sh
-    docker run --name orca_backend -p 8000:8000 -e neo4j_url="http://<neo4j_url:port>" -d stordis/orca_backend:latest
+    docker run --name orca_backend -p 8000:8000 -e neo4j_url="<neo4j_url>" -d stordis/orca_backend:latest
     ```
 
-    If neo4j running on different machine replace `"http://<neo4j_url:port>"` with vm ip and port exposed for to neo4j. 
+    If neo4j running on different machine replace `"<neo4j_url>"` with vm ip and port exposed for to neo4j. 
 
 Container runs on 0.0.0.0:8000 by default. To verify that container has successfully started, try to access http://<server_ip>:8000/admin/ and log in with default user/password- admin/admin which is by default created.
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Use following command to run orca_backend
 docker run --name orca_backend -p 8000:8000 -e neo4j_url="<server_ip>" -d stordis/orca_backend:latest
 ```
 
+> **_NOTE:_**  Replace `"<server_ip>"` with neo4j serve ip.
+
 Container runs on 0.0.0.0:8000 by default. To verify that container has successfully started, try to access http://<server_ip>:8000/admin/ and log in with default user/password- admin/admin which is by default created.
 
 Thats it, If thats enough, rest of the steps below can be skipped and directly proceed with quick start of [orca_ui](https://github.com/STORDIS/orca_ui), which again is as simple as running a docker container and there discover your topology. Else, refer below for more details about build and installation of ORCA backend.
@@ -103,9 +105,10 @@ Similarly, when starting orca_backend container, use it like:
     -e discover_networks="10.10.229.50" \
     -e device_username="admin" \
     -e device_password="YourPaSsWoRd" \
-    -e neo4j_url="orca_neo4j:7687" \
+    -e neo4j_url="<server_ip>" \
     stordis/orca_backend:latest
 ```
+> **_NOTE:_**  Replace `"<server_ip>"` with neo4j serve ip.
 
 [ORCA Network Library Config File](https://github.com/STORDIS/orca_nw_lib/blob/main/orca_nw_lib/orca_nw_lib.yml) is actually the part of one of the dependencies of orca_backend, and the file is installed under site_packages/orca_nw_lib/ directory of python environment being used.
 

--- a/README.md
+++ b/README.md
@@ -43,35 +43,22 @@ ORCA Backend is a REST API server written using Django framework to access orca_
   - [To execute tests](#to-execute-tests)
 
 
-## Quick Start in 3 simple steps
+## Quick Start in 2 simple steps
 ORCA Backend can be started easily by just running 2 docker containers, as follows :
-
-### Create docker network
-Docker networks provide isolated environments for containers to communicate securely and avoid port conflicts.
-
-```sh
-docker network create orca_container_network
-```
 
 ### Run Neo4j docker container
 One of the dependencies for ORCA backend orca_nw_lib uses neo4j to store the network topology. To install neo4j easiest is to run Neo4j Docker image in container with the following command :
 ```sh
-docker run --network=orca_container_network --name orca_neo4j -p7474:7474 -p7687:7687 -d --env NEO4J_AUTH=neo4j/password neo4j:latest
+docker run --name orca_neo4j -p7474:7474 -p7687:7687 -d --env NEO4J_AUTH=neo4j/password neo4j:latest
 ```
-To check that neo4j has successfully started, open https://localhost:7474 with credentials neo4j/password to browse the database.  
+To check that neo4j has successfully started, open https://<server_ip>:7474 with credentials neo4j/password to browse the database.  
 
 ### Run orca_backend docker container
 Use following command to run orca_backend
-- If orca_backend is running on the same machine use below command:
-    ```sh
-    docker run --network=orca_container_network --name orca_backend -p 8000:8000 -e neo4j_url=orca_neo4j:7687 -d stordis/orca_backend:latest
-    ```
-- If neo4j is running on the different machine use below command:
-    ```sh
-    docker run --name orca_backend -p 8000:8000 -e neo4j_url="<neo4j_url>" -d stordis/orca_backend:latest
-    ```
 
-    If neo4j running on different machine replace `"<neo4j_url>"` with vm ip and port exposed for to neo4j. 
+```sh
+docker run --name orca_backend -p 8000:8000 -e neo4j_url="<server_ip>" -d stordis/orca_backend:latest
+```
 
 Container runs on 0.0.0.0:8000 by default. To verify that container has successfully started, try to access http://<server_ip>:8000/admin/ and log in with default user/password- admin/admin which is by default created.
 
@@ -111,8 +98,7 @@ Example -
 
 Similarly, when starting orca_backend container, use it like:
 ```shell
-  docker run --network=orca_container_network -d \
-    --name orca_backend \
+  docker run -d --name orca_backend \
     -p 8000:8000 \
     -e discover_networks="10.10.229.50" \
     -e device_username="admin" \
@@ -170,7 +156,7 @@ If docker image is to be transferred to other machine to run there, first save t
 
 Docker container can be started as follows:
 ```sh
-  docker run --network=orca_container_network --name orca_backend -p 8000:8000 -e neo4j_url=orca_neo4j:7687 -d orca_backend 
+  docker run--name orca_backend -p 8000:8000 -e neo4j_url="<server_ip>" -d orca_backend 
 ```
 
 >**_Note_** - Above command will also create a default django super user with username/password - admin/admin consider changing password afterwards at <http://localhost:8000/admin/> (replace localhost with orca_backend server address)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Use following command to run orca_backend
 docker run --name orca_backend -p 8000:8000 -e neo4j_url="<server_ip>" -d stordis/orca_backend:latest
 ```
 
-> **_NOTE:_**  Replace `"<server_ip>"` with neo4j serve ip.
+> **_NOTE:_**  Replace `"<server_ip>"` with neo4j server ip.
 
 Container runs on 0.0.0.0:8000 by default. To verify that container has successfully started, try to access http://<server_ip>:8000/admin/ and log in with default user/password- admin/admin which is by default created.
 
@@ -108,7 +108,7 @@ Similarly, when starting orca_backend container, use it like:
     -e neo4j_url="<server_ip>" \
     stordis/orca_backend:latest
 ```
-> **_NOTE:_**  Replace `"<server_ip>"` with neo4j serve ip.
+> **_NOTE:_**  Replace `"<server_ip>"` with neo4j server ip.
 
 [ORCA Network Library Config File](https://github.com/STORDIS/orca_nw_lib/blob/main/orca_nw_lib/orca_nw_lib.yml) is actually the part of one of the dependencies of orca_backend, and the file is installed under site_packages/orca_nw_lib/ directory of python environment being used.
 

--- a/README.md
+++ b/README.md
@@ -43,24 +43,29 @@ ORCA Backend is a REST API server written using Django framework to access orca_
   - [To execute tests](#to-execute-tests)
 
 
-## Quick Start in 2 simple steps
+## Quick Start in 3 simple steps
 ORCA Backend can be started easily by just running 2 docker containers, as follows :
+
+### Create docker network
+Docker networks provide isolated environments for containers to communicate securely and avoid port conflicts.
+
+```sh
+docker network create orca_container_network
+```
 
 ### Run Neo4j docker container
 One of the dependencies for ORCA backend orca_nw_lib uses neo4j to store the network topology. To install neo4j easiest is to run Neo4j Docker image in container with the following command :
-        
-    docker run \
-        --name orca_neo4j \
-        -p7474:7474 -p7687:7687 \
-        -d \
-        --env NEO4J_AUTH=neo4j/password \
-        neo4j:latest
+```sh
+docker run --network=orca_container_network --name orca_neo4j -p7474:7474 -p7687:7687 -d --env NEO4J_AUTH=neo4j/password neo4j:latest
+```
 To check that neo4j has successfully started, open https://localhost:7474 with credentials neo4j/password to browse the database.  
 
 ### Run orca_backend docker container
 Use following command to run orca_backend
 
-        docker run --name orca_backend --net="host" -d stordis/orca_backend:latest
+```sh
+docker run --network=orca_container_network --name orca_backend -p 8000:8000 -e neo4j_url=orca_neo4j:7687 -d stordis/orca_backend:latest
+```
 
 Container runs on 0.0.0.0:8000 by default. To verify that container has successfully started, try to access http://<server_ip>:8000/admin/ and log in with default user/password- admin/admin which is by default created.
 
@@ -92,18 +97,23 @@ In the output if install process is stuck at _"[keyring.backend] Loading macOS"_
 ### Configuration
 Device and DB access configurations of orca_backend is configured in [ORCA Network Library Config File](https://github.com/STORDIS/orca_nw_lib/blob/main/orca_nw_lib/orca_nw_lib.yml). All the config parameters defined in this file can simply be overridden by environment variables with the same name as defined in the config file.
 Example -
-
-        export discover_networks="10.10.229.50"
-        export device_username=admin
-        export device_password=YourPaSsWoRd
+ ```sh
+    export discover_networks="10.10.229.50"
+    export device_username=admin
+    export device_password=YourPaSsWoRd
+ ```
 
 Similarly, when starting orca_backend container, use it like:
-
-        docker run --net="host" -d \
-                -e discover_networks="10.10.229.50" \
-                -e device_username="admin" \
-                -e device_password="YourPaSsWoRd" \
-                stordis/orca_backend:latest
+```shell
+  docker run --network=orca_container_network -d \
+    --name orca_backend \
+    -p 8000:8000 \
+    -e discover_networks="10.10.229.50" \
+    -e device_username="admin" \
+    -e device_password="YourPaSsWoRd" \
+    -e neo4j_url="orca_neo4j:7687" \
+    stordis/orca_backend:latest
+```
 
 [ORCA Network Library Config File](https://github.com/STORDIS/orca_nw_lib/blob/main/orca_nw_lib/orca_nw_lib.yml) is actually the part of one of the dependencies of orca_backend, and the file is installed under site_packages/orca_nw_lib/ directory of python environment being used.
 
@@ -138,20 +148,24 @@ Docker image of orca_backend can be created and container cane started as follow
 ### Create docker image
 First create the docker image as follows:
 
-        cd orca_backend
-        docker build -t orca_backend .
+```sh
+    cd orca_backend
+    docker build -t orca_backend .
+```
 
 If docker image is to be transferred to other machine to run there, first save the image, transfer to desired machine and load there as follows:
-
-        docker save -o orca_backend.tar.gz orca_backend:latest
-        scp orca_backend.tar.gz <user_name>@host:<path to copy the image>
-        ssh <user_name>@host
-        cd <path to copy the image>
-        docker load -i orca_backend.tar.gz
+```sh
+    docker save -o orca_backend.tar.gz orca_backend:latest
+    scp orca_backend.tar.gz <user_name>@host:<path to copy the image>
+    ssh <user_name>@host
+    cd <path to copy the image>
+    docker load -i orca_backend.tar.gz
+```
 
 Docker container can be started as follows:
-
-        docker run --net="host" orca_backend
+```sh
+  docker run --network=orca_container_network --name orca_backend -p 8000:8000 -e neo4j_url=orca_neo4j:7687 -d orca_backend 
+```
 
 >**_Note_** - Above command will also create a default django super user with username/password - admin/admin consider changing password afterwards at <http://localhost:8000/admin/> (replace localhost with orca_backend server address)
 


### PR DESCRIPTION
Issue:
A separate Network can be created as follows -
docker network create orca_container_network
Then add all 3 containers orca_ui, orca_backend and neo4j to same network while starting like -
docker run --network=orca_container_network .......................
While runinng for example orca_backend container the neo4j address can be suplied as env_var name = orca_neo4j (container name)
Document should be updated accordingly and should have both the approached with --net="host" and --network=orca_container_network , The later approach is recommended.

Fixes #54 

- added docker network create orca_container_network command in readme.
- modified docker run statement for neo4j with nework.
- modified docker run statement for orcabacked with nework.
- modified docker file to supress createsuperuser error on docker restart