### PR TITLE
 PortChannel - Fixes to check Ip address accepts array #89

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,8 @@
 {
     "python.testing.pytestArgs": [
         "network/test",
-        "authentication/test"
-    ],
+        "authentication/test",
+        "orcask/test"    ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true
 }

--- a/network/port_chnl.py
+++ b/network/port_chnl.py
@@ -110,7 +110,7 @@ def device_port_chnl_list(request):
                         req_data.get("lag_name"),
                         members,
                     )
-                add_msg_to_list(result, get_success_msg(request))
+                    add_msg_to_list(result, get_success_msg(request))
             except Exception as err:
                 add_msg_to_list(result, get_failure_msg(err, request))
                 http_status = http_status and False

--- a/orca_backend/settings.py
+++ b/orca_backend/settings.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/4.2/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.2/ref/settings/
 """
+import os
 
 from pathlib import Path
 
@@ -44,8 +45,12 @@ INSTALLED_APPS = [
     'authentication',
     'rest_framework.authtoken',
     'log_manager',
-    #'ORCASK'
 ]
+
+#check if orcask module is installed 
+if os.path.isdir(os.path.join(BASE_DIR, 'orcask')):
+    print("orcask folder exists.")
+    INSTALLED_APPS.append('orcask')
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",

--- a/orca_backend/urls.py
+++ b/orca_backend/urls.py
@@ -15,14 +15,17 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import include, path, re_path
-
-from network import views
+from django.urls import include, path
+from orca_backend.settings import INSTALLED_APPS
 
 urlpatterns = [
     path("", include("network.urls")),
     path("admin/", admin.site.urls),
     path("auth/", include("authentication.urls")),
     path("logs/", include("log_manager.urls")),
-    #path("orcask/", include("ORCASK.urls")),
 ]
+
+if 'orcask' in INSTALLED_APPS:
+    urlpatterns += [
+        path("orcask/", include("orcask.urls")),
+    ]


### PR DESCRIPTION
issues:
- Check if port channel accepts mutiple ip address.
- if accepts mutiple ip change db property to array to save multiple ip.

Fixes: 
 https://github.com/STORDIS/orca_nw_lib/issues/89
 https://github.com/STORDIS/orca_backend/issues/58

- added new test case to delete ip address without sending ip address in body.
- fixes mutiple responses sending in issue https://github.com/STORDIS/orca_backend/issues/58