### PR TITLE
Interface Primary/Secondary IP configuration. #74

### DIFF
--- a/network/interface.py
+++ b/network/interface.py
@@ -217,6 +217,7 @@ def interface_resync(request):
 
 
 @api_view(["GET", "PUT", "DELETE"])
+@log_request
 def interface_subinterface_config(request):
     """
         Generates the function comment for the given function body.

--- a/network/interface.py
+++ b/network/interface.py
@@ -105,6 +105,7 @@ def device_interfaces_list(request):
                     ),
                     adv_speeds=req_data.get("adv_speeds"),
                     ip_with_prefix=req_data.get("ip_address"),
+                    secondary=req_data.get("secondary", False),
                 )
                 add_msg_to_list(result, get_success_msg(request))
                 http_status = http_status and True
@@ -280,6 +281,7 @@ def interface_subinterface_config(request):
                     device_ip=device_ip,
                     if_name=if_name,
                     ip_with_prefix=ip_address,
+                    secondary=req_data.get("secondary", False),
                 )
                 add_msg_to_list(result, get_success_msg(request))
                 _logger.info("Interface %s ip configured successfully.", if_name)

--- a/network/interface.py
+++ b/network/interface.py
@@ -308,7 +308,12 @@ def interface_subinterface_config(request):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
             try:
-                del_ip_from_intf(device_ip=device_ip, intfc_name=if_name)
+                del_ip_from_intf(
+                    device_ip=device_ip,
+                    intfc_name=if_name,
+                    ip_address=req_data.get("ip_address", ""),
+                    secondary=req_data.get("secondary", False),
+                )
                 add_msg_to_list(result, get_success_msg(request))
                 _logger.info("Interface %s ip deleted successfully.", if_name)
             except Exception as err:

--- a/network/test/test_interface.py
+++ b/network/test/test_interface.py
@@ -507,6 +507,10 @@ class TestInterface(TestORCA):
                 status.HTTP_200_OK,
                 "Port breakout is in progress.",
             )
+            eth_names = int(eth.replace("Ethernet", ""))
+            for i in range(eth_names, eth_names + 3):
+                response = self.get_req("device_interface_list", {"mgt_ip": device_ip, "name": f"Ethernet{i}"})
+                self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
             interface = self.get_req("device_interface_list", {"mgt_ip": device_ip, "name": eth})
             self.assertEqual(interface.json()["breakout_mode"], None)
@@ -710,5 +714,3 @@ class TestInterface(TestORCA):
         # verifying the ip_address deletion
         response = self.get_req("subinterface", {"mgt_ip": device_ip, "name": ether_name})
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-
-


### PR DESCRIPTION
Fixes #74:

- Added code to handle secondary attribute from the interface  and sub-interface API.
- Made changes to support adding a secondary IP to the interface.
- Added test cases to validate the secondary IP.