### PR TITLE
Delete Subscription - Failed to remove subscirption on delete device

### DIFF
--- a/network/test/test_common.py
+++ b/network/test/test_common.py
@@ -6,7 +6,7 @@ import time
 from rest_framework.test import APITestCase
 from rest_framework import status
 from django.urls import reverse
-from orca_nw_lib.gnmi_sub import gnmi_unsubscribe_for_all_devices_in_db
+from orca_nw_lib.gnmi_sub import gnmi_unsubscribe_for_all_devices_in_db, gnmi_subscribe_for_all_devices_in_db
 from django.contrib.auth.models import User
 from orca_nw_lib.gnmi_sub import get_subscription_thread_name, get_running_thread_names
 
@@ -83,6 +83,11 @@ class TestORCA(APITestCase):
         for ip in cls.device_ips:
             thread_name = get_subscription_thread_name(ip)
             cls.assertTrue(thread_name not in get_running_thread_names(), f"Thread {thread_name} is still running")
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        gnmi_subscribe_for_all_devices_in_db() # Subscribe for all devices
 
     def del_port_chnl_ip(self, request_body):
         for data in (

--- a/network/test/test_common.py
+++ b/network/test/test_common.py
@@ -76,6 +76,8 @@ class TestORCA(APITestCase):
                     self.assertEqual(response1.status_code, status.HTTP_200_OK)
                 TestORCA.sync_done = True
 
+        gnmi_subscribe_for_all_devices_in_db()  # Subscribe for all devices
+
     @classmethod
     def tearDownClass(cls) -> None:
         super().tearDownClass()
@@ -83,11 +85,6 @@ class TestORCA(APITestCase):
         for ip in cls.device_ips:
             thread_name = get_subscription_thread_name(ip)
             cls.assertTrue(thread_name not in get_running_thread_names(), f"Thread {thread_name} is still running")
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        gnmi_subscribe_for_all_devices_in_db() # Subscribe for all devices
 
     def del_port_chnl_ip(self, request_body):
         for data in (

--- a/network/test/test_common.py
+++ b/network/test/test_common.py
@@ -8,6 +8,7 @@ from rest_framework import status
 from django.urls import reverse
 from orca_nw_lib.gnmi_sub import gnmi_unsubscribe_for_all_devices_in_db
 from django.contrib.auth.models import User
+from orca_nw_lib.gnmi_sub import get_subscription_thread_name, get_running_thread_names
 
 
 class TestORCA(APITestCase):
@@ -79,6 +80,9 @@ class TestORCA(APITestCase):
     def tearDownClass(cls) -> None:
         super().tearDownClass()
         gnmi_unsubscribe_for_all_devices_in_db()
+        for ip in cls.device_ips:
+            thread_name = get_subscription_thread_name(ip)
+            cls.assertTrue(thread_name not in get_running_thread_names(), f"Thread {thread_name} is still running")
 
     def del_port_chnl_ip(self, request_body):
         for data in (


### PR DESCRIPTION
Issue :

- On device removal stub channel can be closed. Which will eventually kill the subscription thread
- In test cases tear down also the stub channel can be closed.
- There can still remain a method which will remove only the subscription thread not the entire channel.

Fixes [#95](https://github.com/STORDIS/orca_nw_lib/issues/95)

- Function to cancel subscription and then remove thread on retry and timeout.
- Function to close channel and remove thread if exists and remove device from global stub